### PR TITLE
Copy workshop-requirements from coderefinery.org to manuals

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ All material within this repository is licensed [CC-BY](LICENSE).
 
 ### Workshop preparation
 
+- [Workshop basic requirements (in person)][workshop-requirements.md]
 - [Workshop administration](workshop-administration.md)
 - [Guide on how to use Indico](indico-workshop-management.md)
 

--- a/workshop-administration.md
+++ b/workshop-administration.md
@@ -27,7 +27,7 @@ but they make sure that nothing gets forgotten.
 #### First steps
 
 - Recruit instructors - having at least 3 instructors is highly recommended.
-- Find 1-2 workshop helpers [with an appropriate background](https://coderefinery.org/workshop-requirements/#helpers).
+- Find 1-2 workshop helpers [with an appropriate background](workshop-requirements.md).
 - Reserve dates (coordinate this with the instructors)
 - Reserve room
 - Select a workshop coordinator
@@ -36,7 +36,7 @@ but they make sure that nothing gets forgotten.
 #### Lecture room
 
 - Start looking for an appropriate lecture room early.
-- See this [list of requirements](https://coderefinery.org/workshop-requirements/#lecture-room) for
+- See this [list of requirements](workshop-requirements.md) for
   the lecture room.
 
 #### Set up workshop page

--- a/workshop-requirements-inperson.md
+++ b/workshop-requirements-inperson.md
@@ -1,0 +1,59 @@
+## Workshop requirements - in person
+
+
+## Lecture room
+
+- The room needs to be sufficiently large (a typical workshop is attended by
+  around 20 learners and 4 instructors).
+- There needs to be enough space for instructors to walk around and interact
+  with learners individually (a "flat" room is required).
+- Learners should face the same direction, and learners should be able to sit
+  side-by-side for pairwise work.
+- The room should preferably have windows, and be ventilated well enough so
+  that 20-30 people (and same amount of laptops) will not make it too warm.
+- A coffee room (or similar) should be located nearby for the coffee breaks.
+- Two overhead projectors are desirable, but if only one is available that will
+  work too.
+- The projector screen needs to be large, and the resolution of the projector
+  needs to be good.
+- Stable wireless connectivity for 20-30 people.
+- Sufficiently many electricity outlets so that all participants can charge
+  their laptops.
+- Standing board for instructor.
+
+## Helpers
+
+CodeRefinery workshops are hands-on and interactive, and a lot of time is
+spent on exercises where participants learn by doing.  Participants
+explore themselves, and that means they need guides to help them if
+they get stuck.
+
+We recommend that each site takes proactive steps to recruit at least
+two helpers per workshop.  We've noticed that helper diversity
+promotes learning, so we recommend that organizers also make proactive
+steps to have diverse helpers (male/female, international, etc.).
+Local organizers should directly contact possible helpers and invite them.
+
+Good candidates are people who have any of:
+- have attended a previous CodeRefinery workshop
+- have a passion for teaching, scientific software development, open
+  source, open science, etc.
+- are research software engineers or hold a similar technical research position
+- have experience from teaching e.g. Software Carpentry workshops
+- want to experience CodeRefinery but already have a good idea of most basics
+
+
+## Other requirements
+
+When we organize a workshop or event at a new site, we may need help with some local arrangements,
+including:
+
+- Booking a lecture room.
+- Ordering coffee and refreshments.
+- Advertise the workshop through local dissemination channels.
+
+
+## After the workshop
+
+Would you like to [become a helper, instructor, or partner](https://coderefinery.org/get-involved/)
+and make more workshops possible?

--- a/workshop-requirements-inperson.md
+++ b/workshop-requirements-inperson.md
@@ -1,5 +1,8 @@
 ## Workshop requirements - in person
 
+This checklist is for the pre-planning phase of in-person CodeRefinery
+workshops: where you are deciding if you can host one and what room to
+use.  Let us know about the items on this list when you contact us.
 
 ## Lecture room
 


### PR DESCRIPTION
- This copies the requirements to manuals and adds an introduction,
  but doesn't yet remove it from the website or change the website
  links.
- To check: It seems like this is a logical place to put this - what
  do you all think?