### PR TITLE
README: for each page, list the type of material

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,34 +7,34 @@ All material within this repository is licensed [CC-BY](LICENSE).
 
 ### Workshop preparation
 
-- [Workshop basic requirements (in person)](workshop-requirements-inperson.md)
-- [Workshop administration](workshop-administration.md)
-- [Guide on how to use Indico](indico-workshop-management.md)
+- [Workshop basic requirements (in person)](workshop-requirements-inperson.md) (checklist)
+- [Workshop administration](workshop-administration.md) (reference)
+- [Guide on how to use Indico](indico-workshop-management.md) (reference)
 
 
 ### Lesson development
 
 - [Lesson design checklist and guide](lesson-design.md), to make it
-  easy to write your lessons.
-- [Lesson review](lesson-review.md)
+  easy to write your lessons. (tutorial, reference)
+- [Lesson review](lesson-review.md) (checklist)
 
 
 ### Helper training
 
-- [Helper's guide](helping-and-teaching.md)
-- [How helpers manage breakout rooms](breakout-rooms-helping.md)
+- [Helper's guide](helping-and-teaching.md) (tutorial)
+- [How helpers manage breakout rooms](breakout-rooms-helping.md) (tutorial)
 
 ### Teaching
 
-- [In-class checklist](presenting.md)
-- [Online training manual](online-training.md)
-- [Zoom mechanics and signals](zoom-mechanics.md)
-- [Icebreaker question ideas](icebreakers.md)
-- [Hackmd mechanics](hackmd-mechanics.md)
+- [In-class checklist](presenting.md) (checklist)
+- [Online training manual](online-training.md) (tutorial, reference)
+- [Zoom mechanics and signals](zoom-mechanics.md) (tutorial for learners)
+- [Icebreaker question ideas](icebreakers.md) (reference)
+- [Hackmd mechanics](hackmd-mechanics.md) (tutorial for learners)
 - [Summary of the book "Teaching Teach Together"](teaching-tech-together.md)
-  ([the actual book is online](http://teachtogether.tech/))
+  ([the actual book is online](http://teachtogether.tech/)) (reference)
 
 
 ### Writing documentation
 
-- [Writing technical docs](tech-docs.md)
+- [Writing technical docs](tech-docs.md) (reference)


### PR DESCRIPTION
- Classify things into checklist, reference, tutorial.
- To check: last night I thought this would be a good idea, but I'm
  not so sure anymore.  But, it might be useful whene we start having
  muliple pages on a certain topic, for example a tutorial to get
  people started, but also a checklist.
- Anyway, don't merge this unless someone *really* likes it, we can
  wait a week and decide.
- Alternative 1: don't have multiple pages on a certain topyc
- Alternative 2: title makes it clear what is on the page (I am
  thinking this is best now - not this PR)