### PR TITLE
zoom-mechanics: de-emphasize constant muting during discussions

### DIFF
--- a/zoom-mechanics.md
+++ b/zoom-mechanics.md
@@ -14,13 +14,18 @@
 
 ## How to mute and unmute
 
-In lower left corner of the client you an unmute yourself if you want to say
-something but please keep your microphone muted in the main room:
+In lower left corner of the client you can mute and unmute yourself.
 
 <img src="img/unmute.jpg" width="700"/>
 
-If you are in a quiet place, staying unmuted in breakout rooms is reasonable.
-We encourage discussion in breakout rooms.
+In the *main room* during lectures, it is best to keep your microphone
+muted in the main room unless you want to say something.  It's OK to
+unmute and speak up.
+
+If you are in a quiet place, it's best to stay unmuted in breakout
+rooms and during discussions.  This will make discussion much
+smoother - a quiet environment or headset microphone helps with the
+flow a lot.
 
 
 ## Please use your real name (instead of a system default username)


### PR DESCRIPTION
- Muting is one of the things that slows down discussions.  During
  breakout sessions, it's OK if you stay unmuted if you are in a quiet
  enough place or have high-quality equipment.  This will make
  breakout rooms more like a discussion and less like a radio
  conversation, I think.
- We should encourage people to put some effort into finding a quiet
  place or getting equipment.  Of course not everyone can, but we can
  at least point out it's worth making an effort.
- This is only step one of this process.