### PR TITLE
zoom-mechanics: note how you can avoid fullscreen mode

### DIFF
--- a/zoom-mechanics.md
+++ b/zoom-mechanics.md
@@ -98,6 +98,15 @@ Breakout Room" (bottom right):
 There are also signals for faster and slower and with this you can indicate to
 us whether we should adjust the speed.
 
+
+## Zoom doesn't have to fullscreen when someone shares their screen.
+
+By default, when someone shares their screen, Zoom goes into
+fullscreen mode.  This can be inconvenient when you need to see
+multiple windows at once.  You can disable this with Settings → Screen
+Share → "Enter full screen when participants share".
+
+
 ---
 
 This is licensed under [CC-BY](https://github.com/coderefinery/manuals/blob/master/LICENSE)


### PR DESCRIPTION
- When presenting this, the presenter shouldn't spend too much time,
  but note that it can be done
- This can be updated into a section on "how to take part in
  {online|inperson} lessons", which tells people how to mentally and
  physically prepare to make the most of it.  I think it needs to be
  said.