### PR TITLE
how-to-attend: add pages based on recent online workshops

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ teaching/lesson development in general.
 :caption: Learners
 :maxdepth: 1
 
+how-to-attend-online.md
+how-to-attend-inpreson.md
 Zoom mechanics and signals (tutorial for learners) <zoom-mechanics.md>
 Hackmd mechanics (tutorial for learners) <hackmd-mechanics.md>
 ```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ teaching/lesson development in general.
 :maxdepth: 1
 
 how-to-attend-online.md
-how-to-attend-inpreson.md
+how-to-attend-inperson.md
 Zoom mechanics and signals (tutorial for learners) <zoom-mechanics.md>
 Hackmd mechanics (tutorial for learners) <hackmd-mechanics.md>
 ```

--- a/how-to-attend-inperson.md
+++ b/how-to-attend-inperson.md
@@ -1,4 +1,4 @@
-# How to attend online workshops
+# Attending an online workshop
 
 We are glad you would like to attend an in-person workshop.  This page
 will help you mentally and physically prepare.

--- a/how-to-attend-inperson.md
+++ b/how-to-attend-inperson.md
@@ -1,0 +1,104 @@
+# How to attend online workshops
+
+We are glad you would like to attend an in-person workshop.  This page
+will help you mentally and physically prepare.
+
+Our workshops are interactive and hands-on, and you will get the most
+out of them if you can take part in all exercises, unlike a normal
+academic lecture where you mainly listen.  Thus, please read this and
+come prepared!
+
+
+
+## General prerequisites
+
+Check your workshop page for the prerequisites and required software -
+this is not duplicated here!
+
+
+
+## CodeRefinery-specific
+
+- For most workshops, it is important to be a little bit familiar with
+  the command line prompt - not a lot, if you can navigate to
+  directories and edit files, you'll be able to make do.  [This Linux
+  shell crash course](https://scicomp.aalto.fi/scicomp/shell.html)
+  ([video](https://youtu.be/56p6xX0aToI)) is enough.
+- Basics in one or more programming languages.
+- You need to install some software. Please follow links on the
+  workshop page.
+- It is useful if you have a basic idea of how Git works. We will start from
+  the basics anyway, but please go through
+  [this Git-refresher material](https://coderefinery.github.io/git-refresher/)
+  for a basic overview and important configuration steps.
+- Make sure that git is configured, and verify the configuration:
+  [text instructions](https://coderefinery.github.io/installation/git/#configuring-git),
+  [video](https://www.youtube.com/watch?v=WdDTp8NeHBs&t=258s).
+
+
+
+## Take the workshop seriously
+
+It's easy to think "it's just a class, it's easy to passively watch".
+However, for an interactive workshop you do need to take part to get
+the most of out it, and our workshops are targeted to that.  If you
+read this page and the workshop prerequisites, you should be OK.
+
+
+
+## Social
+
+Attend with someone!  Register together and try to sit near them.
+This will create a network of learning and practice that will last
+much longer.
+
+If you can attend a group, that is even better.  You can bring your
+own helper to guide you (if the workshop works this way).  Research
+shows that groups that have multiple adopters have much more uptake of
+new skills.
+
+
+
+## Computer and equipment
+
+Bring your laptop and charger, of course.  If you use external mice,
+etc, it would be good to bring them too.  You'll be on your device a
+lot.
+
+Usually, you'll need to look at both the lesson webpage and the window
+where you are doing the exercises at the same time.  Consider how you
+can arrange windows to do this best.
+
+
+
+## Time management
+
+Try your very best to attend the whole workshops; at least don't miss
+the early sessions.  Later sessions depend on earlier ones, and it's
+easy to get behind.  Tell others this is important so that you can
+free your schedule.
+
+Arrive 10 minutes early to get ready.
+
+
+
+## Software installation
+
+**Do the installation and configuration in advance, and double check
+it.**  In real workshops, problems here slow us down a lot, and if
+you don't prepare, you will immediately fall behind.  If there is a
+pre-workshop session for installation, go there if needed.
+
+If all else fails, come well in advance and ask for help then.
+Usually, there will be enough time to get ready for the day.
+
+
+
+## Final notes
+
+Arrive 10 minutes in advance to get set-up.  There is some advance
+icebreakers and discussion you can take part in, and you get to breath
+before we start.
+
+There is usually discussion after the workshop.  If you want, stick
+around and give us immediate feedback and ask more questions.

--- a/how-to-attend-online.md
+++ b/how-to-attend-online.md
@@ -1,4 +1,4 @@
-# How to attend online workshops
+# Attending an online workshop
 
 We are glad you would like to attend an online workshop.  This page
 will help you mentally and physically prepare.

--- a/how-to-attend-online.md
+++ b/how-to-attend-online.md
@@ -1,0 +1,140 @@
+# How to attend online workshops
+
+We are glad you would like to attend an online workshop.  This page
+will help you mentally and physically prepare.
+
+Our workshops are interactive and hands-on, and you will get the most
+out of them if you can take part in all exercises, unlike a normal
+academic lecture where you mainly listen.  Thus, please read this and
+come prepared!
+
+
+
+## General prerequisites
+
+Check your workshop page for the prerequisites and required software -
+this is not duplicated here!
+
+
+
+## CodeRefinery-specific
+
+- For most workshops, it is important to be a little bit familiar with
+  the command line prompt - not a lot, if you can navigate to
+  directories and edit files, you'll be able to make do.  [This Linux
+  shell crash course](https://scicomp.aalto.fi/scicomp/shell.html)
+  ([video](https://youtu.be/56p6xX0aToI)) is enough.
+- Basics in one or more programming languages.
+- You need to install some software. Please follow links on the
+  workshop page.
+- It is useful if you have a basic idea of how Git works. We will start from
+  the basics anyway, but please go through
+  [this Git-refresher material](https://coderefinery.github.io/git-refresher/)
+  for a basic overview and important configuration steps.
+- Make sure that git is configured, and verify the configuration:
+  [text instructions](https://coderefinery.github.io/installation/git/#configuring-git),
+  [video](https://www.youtube.com/watch?v=WdDTp8NeHBs&t=258s).
+
+
+
+## Take the workshop seriously
+
+It's easy to think "it's just online, it's easy to passively watch".
+However, for an interactive workshop you do need to take part to get
+the most of out it, and our workshops are targeted to that.  If you
+read this page and the workshop prerequisites, you should be OK.
+
+On the other hand, the magic of online events is that anyone can take
+part.  We sometimes have ways for non-interactive participants to take
+part, such as a public stream or recording.  This will be developed
+more later.
+
+
+
+## Social
+
+Attend with someone!  Register together and try to be in their same
+group.  This will create a network of learning and practice that will
+last much longer.
+
+If you can attend a group, that is even better.  You can bring your
+own helper to guide you (if the workshop works this way).  Research
+shows that groups that have multiple adopters have much more uptake of
+new skills.
+
+
+
+## Workspace
+
+Get a good, quiet workspace.  Make sure it is comfortable enough to
+stay at for a while.
+
+An extra monitor is useful but not required, since there is a lot of
+stuff to follow: the stream itself, the lesson webpage, and the window
+where you are doing the assignment.  You could also use a second
+device to watch the stream (but if you do, see the
+[Zoom](zoom-mechanics.md) page for info about screen sharing).
+
+You'll be expected to talk at some times and take part, not simply be
+quiet and listen all the time.  Try to be in a place where you can
+speak without disturbing others.  By the same token, you'll be
+listening for a long time, and your ears may get tired of headphones.
+If you have good enough external speakers, be somewhere that you can
+use them (perhaps only sometimes - when it doesn't interfere with your
+microphone.)
+
+If you work in a large office, consider attending from home or in a
+meeting room so that you can speak and listen more freely.  If you
+need and extra monitor or more comfortable seating space and don't
+have that at home, consider working at your office.  Yes, these are
+conflicting ideas, you need to find what works best for you.
+
+
+
+## Time management
+
+Despite what most people think, attending things online can be harder
+than in-person.
+
+Don't schedule overlapping meetings, reserve the entire timeslots,
+minimze distractions.  It's easy to think you can do multiple things
+at once when doing it online, but really it's a trap.
+
+There will be breaks, but even long ones go by very fast, and this
+gives you limited time to make coffee, eat, etc.  We try to limit
+ourselves to half-days because of this, but consider preparing food,
+coffee, etc. in advance.
+
+Make sure you take the breaks, walk around some, etc.
+
+Join the workshop stream 10 minutes early to get ready.
+
+
+
+## Software installation
+
+**Do the installation and configuration in advance, and double check
+it.**  In real workshops, problems here slow us down a lot, and if
+you don't prepare, you will immediately fall behind.  If there is a
+pre-workshop session for installation, go there if needed.
+
+If all else fails, join the workshop stream well in advance and ask
+for help then.  Usually, there will be enough time to get ready for
+the day.
+
+
+
+## Final notes
+
+Join the stream 10 minutes in advance.  There is some advance
+icebreakers and discussion you can take part in, and you get to breath
+before we start.
+
+There is usually discussion after the workshop.  If you want, stick
+around and give us immediate feedback and ask more questions.
+
+Come to an in-person workshop sometime.  An online workshop probably
+can't replace the experience and individual help you get in person.
+Sign up on the [notify me
+list](https://coderefinery.org/workshops/upcoming/#notify-me) to hear
+about what comes next.


### PR DESCRIPTION
[draft until the sphinx stuff is accepted, then needs TOC linking]

- how-to-attend-online: how to successfully take part online.
- how-to-attend-inperson: same, but for inperson
- Copied from mega-CR and Finland HPC kickstart general information
  and lessons learned.
- This is not designed to replace installation instructions, but more
  general mental and physical preparation.  Should this me moved to
  installation instructions sometime?
- To review: deserves a detailed reading to make sure things are what
  we agree on, typographical errors, and to ensure it general positive
  message and doesn't demotivate people.