### PR TITLE
contributing: Add draft page on contributing to coderefinery

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Writing technical docs (reference) <tech-docs.md>
 :maxdepth: 1
 
 Chat <chat.md>
+Contributing <contributing.md>
 ```
 
 Download this guide as [single-page HTML](https://coderefinery.github.io/manuals/_builds/singlehtml/),

--- a/contributing.md
+++ b/contributing.md
@@ -1,0 +1,127 @@
+# Contributing to CodeRefinery
+
+CodeRefinery is an open-source project.  All our work is open, and we
+accept any random contributions: feel free to make any kind of 
+
+If you aren't sure you are ready for more, you can always lurk
+(passively watch our community) and join when you feel the time is right.
+
+## How to watch and communicate
+
+- Join CodeRefinery chat, give comments or submit emoji reactions to
+  show how you feel about things.  Most things are announced only
+  through zulipchat.
+- Watch GitHub repositories to get notified of issues and pull
+  requests.  Anyone can watch any repository.
+
+## Types of contributions
+
+Some examples of what you can do...
+
+Quick things:
+
+- Fix issues in our lessons, or at least point out problems you see!
+- Contribute to lessons.
+- Help us advertise CodeRefinery to others who can benefit.
+
+A bit more commitment:
+
+- Invite us to give a workshop, serve as a local host and help ensure
+  there are lots of attendees
+- Be a helper with in our workshops.
+
+Get really involved:
+- Hang out on our [CodeRefinery chat](chat)
+- Teach a lesson using our materials yourself
+- Be come a CodeRefinery instructor
+- Come to our meetings several times a month.
+
+
+
+## Example volunteer "packages"
+
+This section gives examples of types of packages you can present to
+your supervisor to make CodeRefinery a part of your job!  Of course,
+we are happy with pure volunteers, but we accept that most people have
+another job and if you can get benefits for your job, you'll have much
+more time for CodeRefinery.
+
+Clearly, these aren't the only ways to contribute, but we thought that
+giving some concrete plans will help people:
+
+
+### Instructor
+
+As an instructor, you become an expert in CodeRefinery materials by
+continual co-working with CodeRefinery staff.  You will really be able
+to help all of your staff
+
+Teach at 4/workshops per year (4 × 3 days) + 50% preparation time
+commitment.  Attend one CodeRefinery workshop per year.
+
+How to get started: be a helper a few times, then as we are planning
+an upcoming workshop, offer to teach something.  We'll help you get
+started.
+
+
+### Helper
+
+As a helper, you have less demands outside of workshops, but you get
+to become very familiar with CodeRefinery material.  You especially
+get skills in mentoring and debugging.  This is a perfect position for
+the "local expert" of a research group, who will guide all of their
+members through getting started with scientific computing.  A helper
+can include all of our non-instructor roles: helper, expert helper,
+Zoom host, etc.
+
+Example time commitment: 4 workshops/year (4 × 3 days) + 20%
+preparation time commitment.
+
+How to get started: Watch our announcements and sign up as a helper.
+
+
+### Lesson maintainer
+
+We have a lot of lessons, and it always helps to have someone keep an
+eye on them and make sure issues and pull requests go thorough.  While
+theoretically everyone helps with this, it's good to have someone keep
+a close watch and make sure there is an overall order to things.  In
+return, you get extensive experience in the topic and experience
+working on an open source project.
+
+Quite often, the current maintainer is the person who last did a major
+re-working of the lesson and an instructor (either active or at the
+final limits of their activity).
+
+Example time commitment: 20-50 hours/year/lesson, plus attending our
+yearly CodeRefinery workshop and meetings several times a month.
+
+How to get started: Watch the GitHub issues and be the first one to
+answer them.  Review pull requests, and if things make sense to you
+then submit a review saying "Approved".  Eventually, you become the
+recognized specialist.  Ask us or we'll notice, and ask you to become
+a maintainer.
+
+
+### Fan
+
+Hang out in the chat and help others, provide advice to others, give
+feedback of our ideas.  Lurk in all of our other activities and decide
+if you want to do more later.
+
+Example time commitment: ???
+
+How to get started: join [CodeRefinery zulipchat](./chat) and see what
+comes up.
+
+
+### Organizer
+
+Help us organize workshops.  Handle attendee communication,
+advertisement, manage helpers, etc.
+
+
+### Create your own lessons in our galaxy
+
+While we are focused on a certain type of packaged workshops, we are
+in principle welcome to other lessons developed in our galaxy.


### PR DESCRIPTION
- This started as a way to present "packaging" of contributing which
  can be presented to your supervisors/organizations, to try to make
  CodeRefinery a part of your job.  I think this is the main benefit
  of this section, we aren't advanced enough that we need to give
  people to participate in other ways.

- But it does include some other ideas about how to contribute.  My
  goal right now isn't to make it a generic "how to contribute to an
  open source project" thing.

- To review: right now, everything.  This is a quick draft.  Is it too
  verbose?  Is it too patronizing?  Are these even ways we expect
  people to contribute?  Each "package" needs thought and elaboration,
  we need to make a good case to the supervisor about it.  And in
  reality, someone will contribute in multiple ways - is that obvious?