### PR TITLE
zoom-mechanics: Add test descriptions for non-image readers

### DIFF
--- a/zoom-mechanics.md
+++ b/zoom-mechanics.md
@@ -4,7 +4,7 @@
 
 ## How to mute and unmute
 
-In lower left corner of the client you can mute and unmute yourself.
+In lower left corner of the client you can mute and unmute yourself:
 
 ![unmute in lower left corner](img/unmute.jpg)
 
@@ -13,31 +13,37 @@ muted in the main room unless you want to say something.  It's OK to
 unmute and speak up.
 
 If you are in a quiet place, it's best to stay unmuted in breakout
-rooms and during discussions.  This will make discussion much
+rooms and during active discussions.  This will make discussion much
 smoother - a quiet environment or headset microphone helps with the
 flow a lot.
 
 
 ## Please use your real name (instead of a system default username)
 
-Click on "Participants" (bottom, middle):
+First, click on **"Participants"** (bottom, middle):
 
 ![participants list button at bottom](img/participants.jpg)
 
-You can rename yourself by clicking the blue "Rename" next to your name:
+You can rename yourself by clicking the blue **"Rename"** next to your
+name that appears when you hover over the button:
 
 ![rename yourself button in participant list](img/rename1.jpg)
+
+A box to rename yourself appears:
 
 ![rename yourself example](img/rename2.jpg)
 
 
 ## Indicate in your name if you are in a team and/or if you are a helper
 
-If you are part of a team, please indicate your team name or number like this:
+If you are part of a team, please indicate your team name or number
+like `(myteam) Your Name`:
 
 ![team name in your Zoom name](img/myteam.jpg)
 
-If you are a helper, please indicate also:
+If you are a helper, please indicate like `(myteam, helper) Your Name`
+also.  The workshop might use the form `(myteam,H) Your Name` instead,
+check what it requests:
 
 ![team name+helper in zoom name](img/myteam-helper.jpg)
 
@@ -49,7 +55,9 @@ This makes it easier for the workshop organizers to manage breakout rooms.
 
 ### How to signal if you are away from keyboard
 
-Please select the "clock" symbol if you are away or otherwise busy:
+Please select the **"clock" symbol** if you are away or otherwise busy.
+You can find this under the "more" icon in at the bottom of the
+participants list:
 
 ![Away from keyboard clock button](img/clock.jpg)
 
@@ -57,14 +65,16 @@ Please select the "clock" symbol if you are away or otherwise busy:
 ### How to signal when you completed a task successfully
 
 We will sometimes ask you to signal to us once you have successfully completed
-an exercise or type-along step. You can do this using the green check symbol:
+an exercise or type-along step. You can do this using the **green "yes"
+check symbol** under the participant list:
 
 ![Green yes under participant list](img/green.jpg)
 
 
 ### How to ask a question
 
-If you want to ask a question please use the "hand" symbol:
+If you want to ask a question please use the **"raise hand" symbol**
+under participant list:
 
 ![Raise hand under participant list](img/hand.jpg)
 
@@ -77,7 +87,7 @@ chat window:
 ### How to signal a technical problem or that you got stuck
 
 If you hit a technical problem or got stuck somewhere in an exercise
-or type-along, please let us know with the red circle symbol:
+or type-along, please let us know with the **red "no" circle symbol**:
 
 ![No button on participant list](img/problem.jpg)
 
@@ -85,15 +95,16 @@ We will then probably ask you to unmute and briefly describe the problem and the
 on the problem and timing we may assign you into a separate virtual room with a helper where
 they can resolve the problem.
 
-Once we have assigned you a helper we will ask you and the helper to "Join
-Breakout Room" (bottom right):
+Once we have assigned you a helper we will ask you and the helper to **"Join
+Breakout Room"** (bottom right):
 
 ![Join Breakout Room button at bottom of screen](img/problem-breakout.jpg)
 
 
 ### How to give feedback on the speed
 
-There are also signals for faster and slower and with this you can indicate to
+There are also signals for **go faster** and **go slower** and with
+this you can indicate to
 us whether we should adjust the speed.
 
 


### PR DESCRIPTION
- Add a few text descriptions, so that someone can understand even if
  they can't see images.
- Also bold the names of buttons to click.
- To review: ensure all the text makes sense.