### PR TITLE
Fix md http links

### DIFF
--- a/indico-workshop-management.md
+++ b/indico-workshop-management.md
@@ -1,7 +1,7 @@
 # Guide on how to use Indico for managing workshops
 
-We use the NeIC Indico service, https://indico.neic.no/, so you need to create
-an account at https://indico.neic.no/login/.
+We use the NeIC Indico service, <https://indico.neic.no/>, so you need to create
+an account at <https://indico.neic.no/login/>.
 
 Radovan, Thor, and Sabry are managers of the CodeRefinery category in
 indico.neic.no and will need to grant you permissions to create event pages.
@@ -15,7 +15,7 @@ which needs to be manually imported as a json file.
 
 ### Copy basics from latest event
 
-- Visit https://indico.neic.no/, and click CodeRefinery which takes you to https://indico.neic.no/category/5/.
+- Visit <https://indico.neic.no/>, and click CodeRefinery which takes you to <https://indico.neic.no/category/5/>.
 - Click the latest workshop event. You might need to show "events in the future" to see the latest event.
 - Go to admin mode (click the pen symbol on top toolbar, “Switch to the management area of this event”).
 - Click the “Clone” button, and select “Clone Once”. Click “Next” button.
@@ -68,7 +68,7 @@ which needs to be manually imported as a json file.
 ### Import survey
 
 - Now click “Surveys” from the left hand menu. You will now import the standard pre-workshop survey from a json file.
-- Go to https://github.com/coderefinery/pre-workshop-survey and clone the repository.
+- Go to <https://github.com/coderefinery/pre-workshop-survey> and clone the repository.
 - Go back to the Indico Surveys page, and click “Create survey”
 - Name the survey “Pre-workshop survey”, enable the option “Anonymous submissions” and disable “Only logged-in users”. Click “Save”.
 - Back on the “Surveys” page, click “Manage” on the newly created “Pre-workshop-survey” survey.

--- a/online-training.md
+++ b/online-training.md
@@ -66,11 +66,11 @@ your time later).
 If you plan to record the session, make sure that everybody is aware that the
 sessions is recorded, informed about how the recording will be used, and gives
 consent to be recorded:
-https://support.zoom.us/hc/en-us/articles/360026909191-Consent-to-be-Recorded
+<https://support.zoom.us/hc/en-us/articles/360026909191-Consent-to-be-Recorded>
 
 In Zoom it's important to start recording in the form you want the video to be
 in (e.g. start recording when screen is shared so that it stays there):
-https://support.zoom.us/hc/en-us/articles/360025561091-Recording-layouts
+<https://support.zoom.us/hc/en-us/articles/360025561091-Recording-layouts>
 
 Set screen background to black. We saw a glitch in Zoom which caused the
 background image to flash above the screen, if it was pure black it would be
@@ -145,4 +145,4 @@ for an in-person event.
 
 ## More resources
 
-- https://foundation.mozilla.org/en/blog/tips-make-your-zoom-gatherings-more-private/
+- <https://foundation.mozilla.org/en/blog/tips-make-your-zoom-gatherings-more-private/>

--- a/workshop-administration.md
+++ b/workshop-administration.md
@@ -15,7 +15,7 @@ but they make sure that nothing gets forgotten.
 
 ## Other documents and references
 
-- Workshop organization overview: https://github.com/orgs/coderefinery/projects/4
+- Workshop organization overview: <https://github.com/orgs/coderefinery/projects/4>
 - Instructions on how to set up a registration page in Indico (for NeIC affiliated staff):
   [indico-workshop-management.md](indico-workshop-management.md)
 - Email templates for workshop communication:
@@ -31,7 +31,7 @@ but they make sure that nothing gets forgotten.
 - Reserve dates (coordinate this with the instructors)
 - Reserve room
 - Select a workshop coordinator
-- Workshop coordinator creates a ticket with a checklist on https://github.com/orgs/coderefinery/projects/4 and takes it (self-assigns)
+- Workshop coordinator creates a ticket with a checklist on <https://github.com/orgs/coderefinery/projects/4> and takes it (self-assigns)
 
 ### Lecture room
 
@@ -41,13 +41,13 @@ but they make sure that nothing gets forgotten.
 
 ### Set up workshop page
 
-- Import the template at https://github.com/coderefinery/template-workshop-webpage to your username
+- Import the template at <https://github.com/coderefinery/template-workshop-webpage> to your username
   or the coderefinery organization, and name it like "2019-10-16-somecity".
 - Update the required fields in `index.md` and push the commits.
   The page should now be served at *username.github.io/2019-10-16-somecity/*.
 - If the workshop will be customized to the needs of a particular audience, modify the schedule accordingly.
-- If the workshop should be listed on https://coderefinery.org:
-  - (Fork and) clone https://github.com/coderefinery/coderefinery.org
+- If the workshop should be listed on <https://coderefinery.org>:
+  - (Fork and) clone <https://github.com/coderefinery/coderefinery.org>
   - Under `coderefinery.org/_workshops/`, add a file named like `2019-10-16-somecity.md` which contains
     the fields permalink, city and dates. For example:
     ```
@@ -115,7 +115,7 @@ For self-organized workshops:
 
 ### Right before the workshop starts
 
-- Prepare a shared Google doc or https://hackmd.io with global write permissions,
+- Prepare a shared Google doc or <https://hackmd.io> with global write permissions,
   consider creating a memorable short-link (e.g. bit.ly)
 
 
@@ -128,7 +128,7 @@ For self-organized workshops:
 ## Workshop preparation checklist
 
 - This checklist can be set up as an issue under 
-  https://github.com/coderefinery/coderefinery.org/ or on another 
+  <https://github.com/coderefinery/coderefinery.org/> or on another
   repository to keep track of the progress
   ```
   - [ ] reserve dates
@@ -161,7 +161,7 @@ For self-organized workshops:
 
 ## Introduction talk
 
-- See https://github.com/coderefinery/workshop-intro
+- See <https://github.com/coderefinery/workshop-intro>
 - Have a 10 minute ice-breaker session where participants and instructors introduce themselves
   and either describe their research in 2-3 sentences or what they hope to get out of the workshop.
 
@@ -193,7 +193,7 @@ For self-organized workshops:
 ## At the end of workshop
 
 - Give credit to those who contributed and helped
-- Use https://github.com/coderefinery/workshop-outro
+- Use <https://github.com/coderefinery/workshop-outro>
 
 
 ## Post-workshop


### PR DESCRIPTION
- Commonmark requires `<http://example.com/>` with the angle brackets
  to auto-detect a link.