### PR TITLE
instructor-intro: Add a pathway to becoming involved

### DIFF
--- a/instructor-intro.md
+++ b/instructor-intro.md
@@ -2,11 +2,25 @@
 
 This page gives general instructor and expert helper introduction
 material.  These people are responsible for more than one breakout
-room, and have to have an overview of more of the course.
+room, and have to have an overview of more of the course.  In short,
+if you want to take the next step in CodeRefinery, this is the place
+to start.
+
+## How do you get started?
+
+That's what this page is about (well, and the [instructor
+training](https://coderefinery.github.io/instructor-training/)).  We
+believe that you best learn by working with others in practice, and
+provide plenty of opportunities to do that.
+
+Prerequisites / software installation:
+- We assume a Zoom desktop client of newer than ~15.october.2020, in
+  order to join breakout rooms by yourself.
 
 
-Reading: the other pages in the section, see sidebar.
+## Starting materials
 
+Reading here: the other pages in the section, see sidebar.
 * {doc}`hackmd-helper`
 * {doc}`expert-helpers`
 * {doc}`host`
@@ -17,3 +31,60 @@ Also read the helper information
 * {doc}`helping-and-teaching` - general on motivation
 * {doc}`breakout-rooms-helping` - read about how to prepare for
   breakout rooms and the role of expert helpers
+
+Reading elsewhere:
+* [CodeRefinery instructor
+  training](https://coderefinery.github.io/instructor-training/)
+* [Carpentries instructor training](https://carpentries.github.io/instructor-training/)
+
+
+
+## From helper to more
+
+Here is one possible pathway from learner to (whatever else).  This is
+an *idea* for a pathway but by no means a requirement - you can join
+at whatever step you like, and steps don't have to happen in order.
+Maybe you are interested in some or the other.  There are also roles
+completely outside of this pathway.
+
+* After being a learner, you come back as a helper.
+* When you have a solid understanding of all materials, you may join
+  as an expert helper.
+* You begin co-teaching episodes with someone else
+  * We find that co-teaching is a good way to start.  In this, there
+    are two people, one person assumes the big-picture discussion, and
+    the other the typing and explaining what they are doing.  By
+    making the lesson a discussion instead of a lecture, it's more
+    dynamic.
+* Eventually, you get confident enough to teach yourself (though
+  really we should always be co-teaching...)
+* Somewhere in there (before or after instructor, depending on your
+  interests), you may want to try to be a HackMD helper or Zoom host.
+  These are more about coordinating all the other people involved in
+  the workshop.
+
+Let's emphasize again: this is one pathway, but you should do what you
+want.
+
+
+
+## As an instructor
+
+Most of our workshops are very collaborative arrangements: you are
+rarely alone.  This is one way of looking at it:
+
+* Look at and revise the workshops before they teach, making small,
+  incremental improvements.  But, you don't have to (and in some
+  sense, it's good if they stabilize some more).
+
+* Have a chat with someone else (probably another instructor or
+  experienced helper) before teaching.  We encourage this for
+  everyone, even experienced instructors, to better transfer knowledge
+  among each other and stay up to date with the latest developments.
+
+* Teach independently or co-teach.  Ideally, co-teach the first
+  time(s).  Really, we'd like to get to the point where we *always*
+  co-teach.  Co-teaching doesn't mean different people take different
+  lessons, but two people teach all parts of the same lesson by
+  turning it into a discussion between the two instructors.  TODO:
+  produce information on this.


### PR DESCRIPTION
- Adjust instructor-intro with more information about the bigger
  picture of being an instructor and getting more involved.
- Perhaps the section and page shouldn't be labeled as just "for
  instructors", but some more general term that describes all of the
  roles beyond helper, since that is the section is about now.
- Review: does this pathway match what we want?  Is it attractive to
  those who would want to join?