### PR TITLE
instructor intro: More comments from last week

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ instructor-intro
 hackmd-helper
 expert-helpers
 host
+workshop-prep-call
 Lesson presentation hints (checklist) <presenting.md>
 instructor-tech-setup
 Summary of the book "Teaching Teach Together" (reference) <teaching-tech-together.md>

--- a/instructor-intro.md
+++ b/instructor-intro.md
@@ -77,6 +77,8 @@ rarely alone.  This is one way of looking at it:
   incremental improvements.  But, you don't have to (and in some
   sense, it's good if they stabilize some more).
 
+* Especially go over the examples when preparing.
+
 * Have a chat with someone else (probably another instructor or
   experienced helper) before teaching.  We encourage this for
   everyone, even experienced instructors, to better transfer knowledge
@@ -88,3 +90,36 @@ rarely alone.  This is one way of looking at it:
   lessons, but two people teach all parts of the same lesson by
   turning it into a discussion between the two instructors.  TODO:
   produce information on this.
+
+
+
+## Top issues new instructors face
+
+- Breaks are not negotiable, minimum 10 minutes.
+
+- Breakout sessions too short.  Make them as long as possible, don't
+  expect to come back for new intro, then go back.
+
+- People will accomplish less than you expect.  Expect learners to be 5
+  times slower than you, at best!
+
+- All the other tools and stuff will go wrong.  Try to not bring in a
+  dependency when you don't need it.
+
+- Trying to accomplish too much: it's OK to cut out and adapt to the
+  audience.  Have a reserve session at the end you prepare, but are
+  ready to skip.
+
+- Explaining how, but not why.
+
+- Running out of time to making your environment match the
+  learner's.
+
+- Running out of time to set up good screen sharing practices
+  (terminal history, portion of screen, remote history) in advance.
+
+- Assuming learners remember what they have already learned, or know
+  the prerequisites.  Or have stuff installed and configured.
+
+- Not managing expectations: learners think that you will accomplish
+  everything, and feel sad when you don't.

--- a/workshop-prep-call.md
+++ b/workshop-prep-call.md
@@ -1,0 +1,46 @@
+# Workshop instructor preparation
+
+Each workshop should have a preparation call among instructors,
+experts, hosts, etc.  This is separate from the [helper training
+call](helper-intro).
+
+
+
+## Topics of workshop instructor meeting
+
+- Introduction round
+- Go over {doc}`instructor-intro` and other pages in this section
+  - New staff: go over in more details.
+- The role of {doc}`expert helpers <expert-helpers>`.
+- Everyone: discuss the roles in the workshop
+- For each lesson, a meeting between a former instructor and the
+  current one (even if current one is experienced teaching it).
+  - Set up any possible co-teaching arrangements.
+- Discuss hand-over times each day
+- Breaks should be descussed among instructors for each day, but
+  default is 10 minutes between xx:50 and xx:10 each hour.
+- Practice instructor tech setup (screenshare, etc): can also be done
+  in the one-on-one meeting.
+- Joining CodeRefinery: what comes next?
+
+
+
+## Don't forget
+
+- Update Zoom client (later than mid-October 2020) for breakout room
+  features.  Zoom alone isn't enough.
+
+
+
+## Common CodeRefinery conventions to remember
+
+- Breaks are not negotiable, minimum 10 minutes
+- Sessions can't be extended indefinitely, it's OK to run out of time
+  and skip things (in fact, we expect this: all lessons have op.  All
+  lessons have optional episodes.  Not finishing is normal, in fact.
+  - Emphasize to learners that we can't cover everything and don't
+    expect to.
+- During workshop, we communicate via:
+  - HackMD
+  - Zulipchat
+  - Zoom chat is minor and most people don't need to watch.


### PR DESCRIPTION
- Make a dedicated "workshop prepa call" page, separate from
  instructor-intro.
- Add "top issues new instructors face".
- Misc new things added
- Review: this is worth reading, though parts have already been read
  in other contexts (instructor training).  Still, this is only one
  part of an iteration.