### PR TITLE
Helper manual fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ Hackmd mechanics (tutorial for learners) <hackmd-mechanics.md>
 
 
 ```{toctree}
-:caption: Helpers
+:caption: Exercise leaders
 :maxdepth: 1
 
-Helper's intro (tutorial) <helper-intro.md>
-Helper's guide (tutorial) <helping-and-teaching.md>
-How helpers manage breakout rooms (tutorial) <breakout-rooms-helping.md>
+Exercise leader's intro (tutorial) <helper-intro.md>
+Exercise leader's guide (tutorial) <helping-and-teaching.md>
+How exercise leaders manage breakout rooms (tutorial) <breakout-rooms-helping.md>
 ```
 
 

--- a/breakout-rooms-helping.md
+++ b/breakout-rooms-helping.md
@@ -3,16 +3,16 @@
 This page is more targeted to online workshops, but could be relevant
 to in-person too.
 
-As a helper, you are what can make a breakout room / group work very
+As an exercise leader, you are what can make a breakout room / group work very
 good or just normal.  This is a lot of responsibility and isn't easy,
 but it's also not that complex: you aren't expected to know
 everything, but instead focus on the flow.  Our guidelines below
 should make it doable for everyone.
 
 Here, we give some hints on making the most of breakout rooms.  This
-is especially targeted towards helpers.
+is especially targeted towards exercise leaders/helpers.
 
-* A **helper** has basic knowledge and keeps one breakout room going.
+* An **exercise leader** has basic knowledge and keeps one breakout room going.
 
 * A **expert helper/instructor** is someone who knows material well,
   possibly an instructor.  They tend to move around helping different
@@ -21,11 +21,11 @@ is especially targeted towards helpers.
 
 ## Background: hierarchical workshops to scale
 
-Traditionally, a workshops has instructors and helpers, but the
+Traditionally, a workshops has instructors and exercise leaders/helpers, but the
 capacity is limited by instructors, so we are limited to ~30-40 people
 at most.  Then, we tried to scale to larger numbers: even up to 100
-people.  For this, we have to rely on *helpers* a lot more, to run a
-breakout room.  A helper does not have to be an expert in the
+people.  For this, we have to rely on *exercise leaders* a lot more, to run a
+breakout room.  An exercise leader does not have to be an expert in the
 material, but should be able to keep things flowing.
 
 
@@ -38,7 +38,7 @@ room as long as we can, but we give no promises and will rearrange as
 needed when people can't attend.
 
 We sometimes allow people to register as teams: you bring learners and
-a helper together, with the hope that you can keep working together
+an exercise leader together, with the hope that you can keep working together
 afterwards.
 
 
@@ -51,7 +51,7 @@ main room and breakout sessions.
   work on something independently as an exercise.**
 - You can try to plan the lesson so that more of it gets pushed to the
   breakout session, and the main room is mostly discussion.  Since
-  each room has a helper, this works a bit better than in in-person
+  each room has an exercise leader, this works a bit better than in in-person
   workshops
   - This doesn't work so well for all lessons.  Especially the more
     basic lessons don't work so well
@@ -81,14 +81,14 @@ opened).
     - 10 minutes is quite short, 20 minutes is best.
     - Can you say less and let people discover it for themselves?
 
-As a helper, if anything is unclear to you, it is very unclear to
+As an exercise leader, if anything is unclear to you, it is very unclear to
 others. Speak up and ask!
 
 (breakout-helpers)=
 
-## Helpers in breakout rooms
+## Exercise leaders in breakout rooms
 
-As a breakout room helper, your main task is to *keep people talking
+As an exercise leader in a breakout room, your main task is to *keep people talking
 and interacting, understand their difficulties, and encourage them to
 work on the exercises together.*
 
@@ -101,10 +101,10 @@ work on the exercises together.*
   room and see what they want, but do provide encouragement to do
   something.
 - If you need extra help, write it in the HackMD, someone should be
-  watching it and relay it to the host.  Other helpers will try to
+  watching it and relay it to the host. Expert helpers/instructors will try to
   visit your rooms periodically, anyway.
 - Watch the time and try to keep things moving.  If some debugging
-  takes to long, it's reasonable to ask for another helper who might
+  takes to long, it's reasonable to ask for another exercise leader/expert helper who might
   have seen the problem.
     - If any one problem takes too long, it's OK to say "we don't have
       time, let's come back"
@@ -120,7 +120,7 @@ questions at the bottom.
 There are several strategies you can use to run your breakout room:
 
 Strategy 1:
-- **Helpers ask someone to share the screen and go through the exercise.**
+- **Exercise leader asks someone to share the screen and go through the exercise.**
 - You can encourage the others to guide the one who is sharing the
   screen. Or let the person go on her/his own pace.
     - I joke "The person who shares the screen has the easiest job,
@@ -166,7 +166,7 @@ Strategy 3:
 
 ## Expert helpers
 
-There's not much difference between a helper and expert helper, but we
+There's not much difference between a exercise leader and expert helper, but we
 envision this role standing by and jumping into rooms when there's a
 difficult problem.
 
@@ -193,7 +193,7 @@ difficult problem.
   join and catch up with the same rooms (this promotes familiarity).
     - E.g. A rotates between rooms 1-3, B gets rooms 4-7, C gets rooms
       8-11.
-- **Make sure to watch the HackMD for helper requests**, this could help
+- **Make sure to watch the HackMD for expert helper requests**, this could help
   you decide which room to jump to next.  Comment when you are heading
   there.
 

--- a/expert-helpers.md
+++ b/expert-helpers.md
@@ -24,8 +24,8 @@ We mainly have expert helpers for large workshops.
   differences between them?  Questions which we should bring up in the
   main room?
 
-* Monitor if any helpers need extra help or training.  Should we
-  improve our helper training?
+* Monitor if any exercise leaders need extra help or training.  Should we
+  improve our exercise leader training?
 
 Other reference:
 

--- a/hackmd-helper.md
+++ b/hackmd-helper.md
@@ -8,7 +8,12 @@ keep people on track.
 
 Below, (*) = important.
 
+## Before the workshop
 
+* Create a new hackmd for the workshop
+* make sure that **editing is enabled for anyone without login**
+* Add workshop information, links to the workshop page and material 
+and an example question and answer to the top of the hackmd (see below)
 
 ## Most things to edit (everyone)
 

--- a/hackmd-mechanics.md
+++ b/hackmd-mechanics.md
@@ -6,6 +6,7 @@
 * provide everyone with a **more equal opportunity to ask questions**.
 * **create notes** which will be archived, for your later reference.
 
+You do not need to login/create an account to be able to edit the document.
 
 ## Basic controls
 

--- a/helper-intro.md
+++ b/helper-intro.md
@@ -1,17 +1,17 @@
-# Helper introduction
+# Exercise leader introduction
 
-Thanks for being a CodeRefinery helper!  Helpers allow CodeRefinery to
+Thanks for being a CodeRefinery exercise leader!  Helpers allow CodeRefinery to
 scale to many more people than we could otherwise handle.  You'll be
 in a breakout room with around 5 people, guide them through the
 course, keep time, and call us when more help is needed.  You'll also
 learn to be
 a more effective teacher and mentor.
 
-As a helper, you are expected to:
+As an exercise leader, you are expected to:
 
 - Show a positive, motivating attitude to learners.
 
-- Come to a one-hour "helper training" before the workshop.
+- Come to a one-hour "Exercise leader training" before the workshop.
 
 - Prerequisites: Have been to a CodeRefinery before and used git some
   since then, or have a bit more some experience with git (branching,
@@ -24,7 +24,7 @@ As a helper, you are expected to:
 
 ## Helper training
 
-During this time, we will talk about the role of the helper during the
+During this time, we will talk about the role of the exercise leader during the
 workshop and answer any open questions you may have.  We'll go through
 the material below.
 
@@ -38,11 +38,11 @@ and if you can't find it then `#general` is good).
 ## Reading
 
 We have these things we recommend you read in advance (don't worry,
-we'll go over them in helper training):
+we'll go over them in exercise leader training):
 
 - [Basics of being a good, motivating helper](helping-and-teaching)
 - {ref}`How breakout rooms work <breakout-helpers>`, focused on
-  sections for helpers.
+  sections for exercise leaders.
 
 
 You'll learn these during the workshop so *you don't need to read
@@ -56,9 +56,9 @@ know this):
   in-person](how-to-attend-inperson), but you learn this in class.
 
 
-## From helper to instructor
+## From exercise leader/helper to instructor
 
-If you enjoy being a helper, would you like to upgrade to a more
+If you enjoy being an exercise leader, would you like to upgrade to a more
 active role in CodeRefinery, or become an instructor?  We welcome
 everyone to the CodeRefinery community and want to expand our network
 of workshops and instructors.

--- a/helping-and-teaching.md
+++ b/helping-and-teaching.md
@@ -1,21 +1,20 @@
-# Tips for helpers
+# Tips for exercise leaders
 
-This page contains the most important general hints for helpers for
-helpers.  See the {doc}`helper-intro` for more.
+This page contains the most important general hints for exercise leaders. See the {doc}`helper-intro` for more.
 
 
 ## Preparing to help
 
-As a helper, we do not expect you to know all our [CodeRefinery training material](https://coderefinery.org/lessons/) but if you have time:
+As an exercise leader, we do not expect you to know all our [CodeRefinery training material](https://coderefinery.org/lessons/) but if you have time:
 
-- If you aren't sure if you can be a helper: you probably can be one!
+- If you aren't sure if you can be an exercise leader: you probably can be one!
 - We try to make each exercise self-explanatory, but if you do one
   thing, scan over the exercises and understand the general point of
   each of them.
 - Read through the instructor guides for the lessons (there should be
   a link at the top or sidebar of each lesson).
 - Be ready to introduce yourself in one or two sentences: think about what you
-  would like to convey as helpers to the classroom. How did (or does)
+  would like to convey as exercise leader to the classroom. How did (or does)
   CodeRefinery help you?
 
 
@@ -31,7 +30,7 @@ please mention it to one of instructors.
 
 ### Creating a positive learning environment
 
-As a helper, you have a crucial role during workshops:
+As an exercise leader, you have a crucial role during workshops:
 
 - Encourage learners to learn from each other.
 - Acknowledge that some of the material can be difficult and that they will
@@ -83,4 +82,3 @@ As a helper, you have a crucial role during workshops:
 * Carpentries instructor training
 * {doc}`Teaching Tech Together <teaching-tech-together>` chapters 8,
   9, 10.
-  

--- a/how-to-attend-inperson.md
+++ b/how-to-attend-inperson.md
@@ -53,7 +53,7 @@ This will create a network of learning and practice that will last
 much longer.
 
 If you can attend a group, that is even better.  You can bring your
-own helper to guide you (if the workshop works this way).  Research
+own exercise leader to guide you (if the workshop works this way).  Research
 shows that groups that have multiple adopters have much more uptake of
 new skills.
 

--- a/instructor-intro.md
+++ b/instructor-intro.md
@@ -27,7 +27,7 @@ Reading here: the other pages in the section, see sidebar.
 * {doc}`presenting`
 * {doc}`instructor-tech-setup`
 
-Also read the helper information
+Also read the exercise leader information
 * {doc}`helping-and-teaching` - general on motivation
 * {doc}`breakout-rooms-helping` - read about how to prepare for
   breakout rooms and the role of expert helpers
@@ -39,7 +39,7 @@ Reading elsewhere:
 
 
 
-## From helper to more
+## From exercise leader/helper to more
 
 Here is one possible pathway from learner to (whatever else).  This is
 an *idea* for a pathway but by no means a requirement - you can join
@@ -47,7 +47,7 @@ at whatever step you like, and steps don't have to happen in order.
 Maybe you are interested in some or the other.  There are also roles
 completely outside of this pathway.
 
-* After being a learner, you come back as a helper.
+* After being a learner, you come back as an exercise leader/helper.
 * When you have a solid understanding of all materials, you may join
   as an expert helper.
 * You begin co-teaching episodes with someone else
@@ -80,7 +80,7 @@ rarely alone.  This is one way of looking at it:
 * Especially go over the examples when preparing.
 
 * Have a chat with someone else (probably another instructor or
-  experienced helper) before teaching.  We encourage this for
+  expert helper) before teaching.  We encourage this for
   everyone, even experienced instructors, to better transfer knowledge
   among each other and stay up to date with the latest developments.
 


### PR DESCRIPTION
Updating the helper manuals:

1. replaced helper with exercise leader
    In some places in the text I left the helper or added / exercise leader
2. added info on how to prepare hackmd before the course, with info to enable editing by anyone without login
3. added info for learners that they do not need to login to edit the hackmd


2. and 3. close #145 
