### PR TITLE
zoom-mechanics-old: Remove now-unneeded reference target

### DIFF
--- a/zoom-mechanics-old.md
+++ b/zoom-mechanics-old.md
@@ -1,4 +1,3 @@
-(how-to-zoom)=
 # Zoom mechanics and controls
 
 


### PR DESCRIPTION
- Remove `how-to-zoom` from zoom-mechanics-old, it is now in
  zoom-mechanics (the new one).