### PR TITLE
Add a meeting checklist to stream annoucements

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Lesson review checklist <lesson-review.md>
 :maxdepth: 1
 
 Writing technical docs (reference) <tech-docs.md>
+meeting-checklist
 ```
 
 ```{toctree}

--- a/meeting-checklist.rst
+++ b/meeting-checklist.rst
@@ -1,0 +1,89 @@
+Meeting checklist
+=================
+
+This checklist was made because we had a major issue with *not
+announcing good events* to our community because we weren't sure what
+to do, thus a community doesn't form.  These steps should be taken to
+announce any event unless there is a specific reason not to (for
+example, a workshop is well underway and organizers known).  You don't
+*have* to follow what you see here, but the point is to make
+announcements as boring as possible, so that it gets done quickly and
+well-enough.
+
+
+As soon as meeting topic/time is decided
+----------------------------------------
+
+* Decide central HackMD/join link.  (Join link can be decide later by
+  putting it in the hackmd).
+
+* Create a calendar event for yourself, and send it to related
+  people.  You should be ready to forward this to people who request.
+  It's OK if the event only includes HackMD link (+ join link, if
+  known).
+
+* [Mailing list: not yet present, we are relying on the other options
+  here.]
+
+* Make a post in #announcements.  Don't be shy, just do it.
+  ``<time:``\ TAB will produce a time picker that adjusts for
+  everyone's timezones.
+
+  ::
+
+     At <time:...>, there will be a [meeting on topic].  Topics will
+     include [a few highlights to let people know who should attend].
+
+     HackMD (including connection details): <link>
+     More info: #[stream-name]
+
+     If you want a calendar invite, send [me] a private message (or
+     react with :email: quickly if I know your email already).
+
+* Make a Twitter post for most meetings, if you want a broader
+  community to attend.
+
+  * You can do this yourself via the "tweet-together" Github Action:
+
+    * CodeRefinery:
+      https://github.com/coderefinery/coderefinery-twitter/
+    * Nordic-RSE:
+      https://github.com/nordic-rse/
+    * Research Software Hour: CR + AaltoSciComp
+
+  * You can do it from the web interface, find the "Create new tweet"
+    button from the readme.
+
+  * Edit the file path.  It pre-fills ``YYYY/MM`` outside of the text
+    box, but you can backspace and change that to current year/month.
+
+  * Suggested template::
+
+      [title] will be held at [time CEST]. [optional: why should
+      someone attend?  Attend if...]
+
+      More info via our chat https://coderefinery.github.io/manuals
+      [tags]
+
+  * Suggested tags
+
+    * CodeRefinery: ``#coderefinery``
+    * Nordic-RSE: ``#rseng``
+    * Research software hour: ``#rseng``
+
+  * Someone else should merge immediately after checking facts
+    (ideally have merged by the time the meeting ends).  Don't wait
+    for "permission" or something like that which may never come.
+
+
+
+Days before the meeting
+------------------------
+* Send reminders to the #announcements streams.  You can find the old
+  topic and reply to it, quoting the whole text.
+
+
+
+Archive meeting agenda
+----------------------
+* Archive the agenda, if needed.


### PR DESCRIPTION
- We realized that announcing events and reaching the community was a
  major barrier, so we needed clear steps of what to do (not to limit
  people, but to make sure people know it's OK to be broad in
  communication).

- This provides some minimum mechinacal steps that everyone can do.

- Review: could use a good read and more improvements, or simplify
  when not needed.
