### PR TITLE
how-to-attend-*: Update pages, add livesteam page

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ They are a starting point: feel free to be adventurous.
 :maxdepth: 1
 
 how-to-attend-online.md
+how-to-attend-stream.md
 how-to-attend-inperson.md
 Zoom mechanics and signals (tutorial for learners) <zoom-mechanics.md>
 Hackmd mechanics (tutorial for learners) <hackmd-mechanics.md>

--- a/how-to-attend-inperson.md
+++ b/how-to-attend-inperson.md
@@ -11,30 +11,20 @@ come prepared!
 
 
 
-## General prerequisites
+## General prerequisites, software installation, etc.
 
-Check your workshop page for the prerequisites and required software -
-this is not duplicated here!
+Check your workshop page for the general setup specific to that
+workshop.
+
+- Often, there is something to install.  We usually ask you to install
+  things so that your computer is set up to do work later.
+- There may be some basic skills, such as the command line shell, to
+  review in advance.
 
 
-
-## CodeRefinery-specific
-
-- For most workshops, it is important to be a little bit familiar with
-  the command line prompt - not a lot, if you can navigate to
-  directories and edit files, you'll be able to make do.  [This Linux
-  shell crash course](https://scicomp.aalto.fi/scicomp/shell.html)
-  ([video](https://youtu.be/56p6xX0aToI)) is enough.
-- Basics in one or more programming languages.
-- You need to install some software. Please follow links on the
-  workshop page.
-- It is useful if you have a basic idea of how Git works. We will start from
-  the basics anyway, but please go through
-  [this Git-refresher material](https://coderefinery.github.io/git-refresher/)
-  for a basic overview and important configuration steps.
-- Make sure that git is configured, and verify the configuration:
-  [text instructions](https://coderefinery.github.io/installation/git/#configuring-git),
-  [video](https://www.youtube.com/watch?v=WdDTp8NeHBs&t=258s).
+If all else fails, join the workshop well in advance and ask
+for help then.  Usually, there will be enough time to get ready for
+the day.
 
 
 
@@ -83,16 +73,6 @@ Arrive 10 minutes early to get ready.
 
 
 
-## Software installation
-
-**Do the installation and configuration in advance, and double check
-it.**  In real workshops, problems here slow us down a lot, and if
-you don't prepare, you will immediately fall behind.  If there is a
-pre-workshop session for installation, go there if needed.
-
-If all else fails, come well in advance and ask for help then.
-Usually, there will be enough time to get ready for the day.
-
 
 
 ## Final notes
@@ -103,3 +83,7 @@ before we start.
 
 There is usually discussion after the workshop.  If you want, stick
 around and give us immediate feedback and ask more questions.
+
+Sign up on the [notify me
+list](https://coderefinery.org/workshops/upcoming/#notify-me) to hear
+about what comes next.

--- a/how-to-attend-stream.md
+++ b/how-to-attend-stream.md
@@ -1,7 +1,7 @@
 (attend-online)=
-# Attending a Zoom workshop
+# Attending an livestream workshop
 
-We are glad you would like to attend an online workshop.  This page
+We are glad you would like to attend an livestream workshop.  This page
 will help you mentally and physically prepare.
 
 Our workshops are interactive and hands-on, and you will get the most
@@ -9,6 +9,14 @@ out of them if you can take part in all exercises, unlike a normal
 academic lecture where you mainly listen.  Thus, please read this and
 come prepared!
 
+A livestream workshop allow us to reach an unlimited number of people,
+at the cost of not being as interactive.  Still, we have solutions:
+- You might register to Zoom breakout rooms, which *are* interactive.
+- {doc}`HackMD <hackmd-mechanics>` allows you to ask questions anonymously -
+  even better than a normal workshop!  Once we have a few tens of people in
+  any workshop, people don't ask voice questions anyway.
+- In some workshops, you can register for breakout rooms to get
+  interactive assistance during the exercise/breakout sessions.
 
 
 ## General prerequisites, software installation, etc.
@@ -35,12 +43,17 @@ the day.
 ## Take the workshop seriously
 
 It's easy to think "it's just online, it's easy to passively watch".
-However, for an interactive workshop you do need to take part to get
+However, for an interactive experience you do need to take part to get
 the most of out it, and our workshops are targeted to that.  If you
 read this page and the workshop prerequisites, you should be OK.
 
 *Don't do multiple meetings*, *reserve the entire timeslots on your
 calendar*, *attend every session*, *do the preparation*.
+
+On the other hand, the point of livestreaming is that someone can
+passively watch without taking a seat from others.  If you want to
+watch without interacting, that is OK too!  Please don't take an
+interactive seat from others and consider returning actively later.
 
 
 
@@ -65,10 +78,10 @@ stay at for a while.
 An extra monitor is useful but not required, since there is a lot of
 stuff to follow: the stream itself, the lesson webpage, and the window
 where you are doing the assignment.  You could also use a second
-device to watch the stream (but if you do, see the
-[Zoom](zoom-mechanics.md) page for info about screen sharing).
+device to watch the stream.
 
-You'll be expected to talk at some times and take part, not simply be
+If you have registered to attend breakout rooms, you'll be expected
+to talk at some times and take part, not simply be
 quiet and listen all the time.  Try to be in a place where you can
 speak without disturbing others.  By the same token, you'll be
 listening for a long time, and your ears may get tired of headphones.
@@ -104,11 +117,15 @@ Make sure you take the breaks, walk around some, etc.
 
 
 
-## Live streaming
+## Communication
 
-If the workshop is also streamed, see
-{doc}`Live streaming <how-to-attend-livestream>` for how to attend that
-way.
+Most communication goes through [HackMD](hackmd-mechanics). Make sure
+that you have it open and practice during the icebreakers.  This is
+much better than chat, since you can ask anonymously, you can ask at
+the same time as others, and multiple people can answer.  We recommend
+you don't use chat, messages tend to get lost if not answered
+immediately.
+
 
 
 


### PR DESCRIPTION
- Update and make these pages consistent (using diffing between them
  and porting improvements in one to others)

- how-to-attend-livestream: Add a new page, based on
  how-to-attend-online.  This is copy-and-paste and modification,
  using a graphical diff tool.  I am a bit unhappy how there are three
  similar pages now, perhaps we can combine them using sphinx-tabs later.

- Remove some 'general prep' stuff (shell, git, etc), it is now also
  in the template-workshop-webpage.  This is workshop specific, and
  these pages are becoming more generic and will be linked from many
  different workshops (like python-for-scicomp).

- Review:

  - Overall probably doesn't need too much review, instead merge +
    iterate.

  - how-to-attend-{inperson,online}: These can be directly checked
    using the github diffs.  There is probably not too much
    controversial in here.

  - how-to-attend-stream: Most of this info is redundant, so I would
    scan it and see the interesting sections that are different from
    -online, or use a diff program locally.  (I'm sorry for not doing
    it in two commits, oh well)
