### PR TITLE
merge the onboarding with EL background info

### DIFF
--- a/exercise-leaders.md
+++ b/exercise-leaders.md
@@ -1,293 +1,161 @@
 # Exercise leaders
 
-## Onboarding material
-
-### Thanks for being an exercise leader :heart: 
-
-Without you, these large online workshops would not be possible!
-
-### Agenda
-
-1. Introduction and Icebreaker
-2. Reviewing learners survey 
-3. Short overview on what will happen in workshop
-    - teams
-    - stream vs zoom
-    - main session vs breakoutrooms
-    - HackMD and expert helpers
-4. [How to be an exercise leader](https://coderefinery.github.io/manuals/helping-and-teaching/)
-    - Code of conduct
-    - positive learning environment
-    - things to avoid
-5. [In breakoutrooms](https://coderefinery.github.io/manuals/breakout-rooms-helping/#helpers-in-breakout-rooms)
-    - Helper as moderator and time keeper
-    - breakoutroom strategies
-    - common problems
-6. Path ahead with CodeRefinery
-7. Open questions
-8. Transition to installation help
+We use this page during exercise leader onboarding.
+**Thanks for being an exercise leader :heart:**!
+Without you, these large online workshops would not be possible.
 
 
-#### 1. Introduction, Icebreaker, Zulip
+## Onboarding session: Introduction, icebreaker, and project chat
 
-> CodeRefinery: We are working with students, researchers, and research software engineers from all disciplines to advance FAIRness of software management and development practices so that research groups can collaboratively develop, review, discuss, test, share and reuse their codes.
-* Get familiar with HackMD 
+We usually offer two one-hour timeslots in the week before the workshop (check
+the schedule!) for exercise leader onboarding. You are expected to join one of
+these times. During this time, we will talk about the role of the exercise
+leader during the workshop and answer any open questions you may have. We will
+also go through the material below.
 
-[HackMD Mechanics](https://coderefinery.github.io/manuals/hackmd-mechanics/)
+* CodeRefinery: We are working with students, researchers, and research
+  software engineers from all disciplines to advance FAIRness of software
+  management and development practices so that research groups can
+  collaboratively develop, review, discuss, test, share and reuse their codes.
 
-* Shortly introduce yourself in zoom
+* Get familiar with HackMD ({ref}`how-to-hackmd`)
+
+* Shortly introduce yourself in Zoom
     * Who are you?
     * What do you do?
     * Where are you connecting from?
 
-* If you want to, sign up for our [zulip chat](https://coderefinery.zulipchat.com) to ask us anything, anytime. Use `#tools-workshop` during the workshop itself (you need to join the stream)
+* If you want to, sign up for our [Zulip chat](https://coderefinery.zulipchat.com) to ask us anything, anytime. Use
+  `#tools-workshop` during the workshop itself (you need to join the stream).
 
 
-#### 2. Learners survey
+## Reviewing learners survey
 
-(we used to ask learners to fill out a pre-workshop survey; this is discontinued now but results of the surveys still apply)
-Let's take a quick look at previous courses survey results:
-
-https://github.com/coderefinery/pre-workshop-survey
-
-
-
-#### 3. What will happen during workshop?
-
-[Schedule](https://coderefinery.org/2022-09-22-workshop/#schedule) with link to lesson material and exercises
+We used to ask learners to fill out a pre-workshop survey. This is discontinued
+now but results of the surveys still apply.  Let's take a quick look at
+previous courses survey results:
+<https://github.com/coderefinery/pre-workshop-survey>
 
 
-##### Interactive stream?
+## What will happen during workshop?
 
-* Instructor zoom is streamed
-    * watch material, watch demo, type along
-* Learner zoom for exercise sessions in breakoutrooms
+Please review the workshop schedule, e.g.
+<https://coderefinery.github.io/2022-09-20-workshop/schedule/>. It
+contains links to lesson material and exercises.
+
+**Interactive stream?**
+* Instructor Zoom is streamed and recorded (watch material, watch demo, type along)
 * Stream for everyone
-* interaction of everyone via [HackMD](https://hackmd.io/@coderefinery/workshop-2022-september)
+* Learner Zoom for exercise sessions in breakout rooms (no recording)
+* Everybody interacts via HackMD
 
-#### 4. Exercise sessions
 
-* instructor should clearly tell which exercises and for how long; if you don't know please clarify via HackMD
-
-##### Teams?
-
-###### preformed teams
-
-* learners could sign up as team
-* the goal is to keep preformed teams together 
-
-###### single learner teams
-
-* learners could sign up alone but request to do the exercises in team
-* -> 2 open breakoutrooms
-* Additional rooms for specific problem solving 
-* Learners can also create own team 
-
-
-##### Want extra help?
-
-:::warning
-**It is ok to not know something!**
-:::
-
-We have structures in place to help you if there is questions that you cannot answer (HackMD, expert helpers)
-
-Use HackMD:
-
-![](https://i.imgur.com/5UIwy5c.png)
-
-* to ask (and answer) general questions that came up in your room 
-* to call for more help from our expert helpers
-
-##### During exercise sessions
-
-[Helping in breakoutrooms](https://coderefinery.github.io/manuals/breakout-rooms-helping/#helpers-in-breakout-rooms)
-
-* keep people talking and interacting, understand their difficulties, and encourage them to work on the exercises together.
-* Greeting
-* cameras
-* Chat to “Everyone” in a breakout room only means people in that room.
-* read the room and see what they want, but do provide encouragement to do something.
-* keep time and ask for extra help with debugging
-
-
-###### Strategies
-
-**Strategy 1:** Encourage to share screen
-**Strategy 2:** Everyone does exercise themselves and ask if there is questions
-**Strategy 3:** Share own screen
-
-
-###### Common problems
-
-* one person asking a lot
-* larger / technical problems
-* too little time
-
-
-###### How to be an exercise leader
-
-[How to be an exercise leader](https://coderefinery.github.io/manuals/exercise-leaders/)
-
-
-##### Before 
-
-* check out the exercises 
-    * every lesson has a "List of Exercises" under "References"
-    * note that some exercises are optional (and will probably not be done during workshop unless people are very fast)
-> think about what you would like to convey as exercise leader to the classroom. How did (or does) CodeRefinery help you?
-* if interested, check out instructor guide of lessons
-
-
-##### During
-
-* [Code of Conduct](https://docs.carpentries.org/topic_folders/policies/code-of-conduct.html)
-* Positive learning environment
-    * encourage learning from each other
-    * acknowledge difficulties and confusions
-    * introductory round and camera
-* Rename yourself in zoom to reflect your team name and that you are EL
-
-
-##### Please do not
-
-* Take over learners keyboard, you can share commands in chat
-* Criticize certain programs, operating systems, or GUI applications, or learners who use them. (Excel, Windows, etc.)
-* Talk contemptuously or with scorn about any tool. 
-* Dive into complex or detailed technical discussions
-* Pretend to know more than you do. Better to put a question on HackMD then. Trust.
-* Use “just”, “easy”, "simply", "basic", "trivial" or other demotivating words. 
-* “I can’t believe you don’t know X” 
-
-
-#### 6. Path ahead
-
-Would you like to
-* become an instructor?
-* help organizing a workshop?
-* contribute to lesson material?
-* have any other ideas to contribute?
-* community calls in future: see https://coderefinery.org/organization/meetings/
-
-See our [website](https://coderefinery.org/get-involved/) and [Manuals](https://coderefinery.github.io/manuals/contributing/)
-Best way to get started is to join the [zulip chat](https://coderefinery.zulipchat.com)
-
-
-#### 7. Open questions?
-
-
-#### 8. Installation help
-
-...coming up after this session:
-Please stick around, in case learners show up with installation issues, you may also observe
-
----
-
-Exercise Leaders are an essential part of the CodeRefinery workshop team and allow CodeRefinery to scale to many more people than we could otherwise handle.  During a (n online) workshop, Exercise leaders will be in a breakout room (virtual side room) with around 5 people, guide them through the course, keep time, and let us know when more help is needed during the exercise sessions. Instructors and expert helpers are always just one click away. 
-It is very likely that you'll grow as a mentor and learn how to be a more efficient teacher. 
-
-## Background: hierarchical workshops to scale
-
-Traditionally, a workshop has instructors and exercise leaders/helpers, but the
-capacity is limited by instructors, so we are limited to ~30-40 people
-at most.  Then, we tried to scale to larger numbers: even up to and beyond 100
-people.  For this, we have to rely on *exercise leaders* a lot more, to run a
-breakout room.  An exercise leader does not have to be an expert in the
-material, but should be able to keep things flowing.
-
-## What is needed to be an exercise leader?
-
-Most importantly, *you do not have to know everything* (we don't, either), but you are expected to:
-
-- Have been to a CodeRefinery before and used git some since then, OR have some general experience with git (branching,
-  pull requests) and command line work, OR be able to generally follow
-  the path of the exercises that we have laid out.
-
-- Be present in your assigned breakout room during exercise sessions of the workshop.
-
-- Show a positive, motivating attitude to learners.
-
-- Keep exercises going and let us know when there are difficult questions!
-
-- Come to a one-hour "Exercise leader onboarding" (see below) before the workshop.
-
-> If you aren't sure if you can be an exercise leader: you probably can be one!
-
-
-## Teams
-
-We try to arrange people in teams which stay together for all breakout
-sessions on all days.  This allows people to form a bond and get the
-rooms started sooner.  We will try to keep you in the same breakout
-room as long as we can, but we give no promises and will rearrange as
-needed when people can't attend.
-
-We sometimes allow people to register as teams: This could for example be a group colleagues/friends where one of the team members has a bit of knowledge on the tools presented in the workhop. This person can act as exercise leader for the workshop, but may still learn a thing or two themselves. In that way you can work with people you know and the barrier for asking questions and discuss together may be a bit lower than in a group of strangers. Since teams with exercise leaders are 'self-sustaining' we usually accept all team registrations, while registrations as single learner may be put on waiting list or, if applicable redirected to the stream, when they exceed our capacity based on the number of individual exercise leaders. 
-
-
-## Exercise leader onboarding
-
-We usually offer two one-hour timeslots in the week before the workshop (check the schedule!) for exercise leader onboarding. You are expected to join one of these times. During this time, we will talk about the role of the exercise leader during the workshop and answer any open questions you may have. We will also go through the material below.
-
-## Material for exercise leaders
-
-If you have been to a CodeRefinery workshop before, you will most likely know the following, but if unsure, also check these links: 
-
-- {ref}`HackMD mechanics <how-to-hackmd>`
-- {ref}`Zoom mechanics <how-to-zoom>` (if the workshop uses Zoom)
-- "How to attend" whatever kind of workshop we are doing (though we
-  will cover this the first day, too): {ref}`how to attend via livestream
-  <attend-stream>`, {ref}`how to attend via Zoom <attend-online>`, or 
-  {ref}`how to attend in-person <attend-inperson>`.
-
-If you have any doubts, questions, ideas or anything you want to tell
-us apart from these sessions, please let us know! We are here to help. 
-
-If you want to contact us before the workshop you can send an email to our general email address <support@coderefinery.org> or you can join the
-{doc}`CodeRefinery chat <chat>` (we recommend the `#workshops` stream,
-and if you can't find it then `#general` is good). During the
-workshop, we use a topic in `#workshop-chat` to coordinate (exercise
-leaders do *not* need to use this, use HackMD instead).
-
-During the workshop, HackMD (collaborative document) is our main communication channel, where you can ask questions or request us to visit your breakout room in case of tricky questions or further discussion potential.
-
-If you had fun being an exercise leader for the workshop, please visit our {ref}`contributing page <volunteering>` page, to find out about further volunteering possibilities within CodeRefinery.
-
-(helper-tips)=
-## Tips for exercise leaders
-
-As an exercise leader, you are what can make a breakout room / group work very
-good or just normal.  This is a lot of responsibility and isn't easy,
-but it's also not that complex: you aren't expected to know
-everything, but instead focus on the flow.  Our guidelines below
-should make it doable for everyone.
-
-### Before the workshop
+## Preparing for the workshop
 
 As an exercise leader, we do not expect you to know all our [CodeRefinery training material](https://coderefinery.org/lessons/) but if you have time:
 
-- Take a look at the exercises in advance of each days (revised
+- **Take a look at the exercises in advance** of each days (revised
   lessons tend to have an "exercise list" page).  We try to make each
   exercise self-explanatory so that you can easily lead, but if you do one
   thing, scan over the exercises and understand the general point of each of them.
-- Be ready to introduce yourself in one or two sentences to your breakout room: think about what you
+- **Be ready to introduce yourself** in one or two sentences to your breakout room: think about what you
   would like to convey as exercise leader to the classroom. How did (or does) CodeRefinery help you?
-- If you are interested, also read through the instructor guides for the lessons (there should be
+- If you are interested, also read through the **instructor guides** for the lessons (there should be
   a link at the top or sidebar of each lesson).
 
-### During the workshop
 
-#### Code of Conduct
+## Exercise sessions
 
-Teaching isn't about helping those who are already "in", it is for
-those who aren't.  Thus, we follow [a code Codee of
-Conduct](https://coderefinery.org/about/code-of-conduct/) for all our
-interactions before, during and after workshops.
+* Instructor should clearly tell which exercises and for how long; if you don't know please clarify via HackMD
 
-If you see anything that is not supporting an equal learning environment,
-please mention it to one of instructors.
+**Preformed teams**:
+* Learners could sign up as team
+* The goal is to keep preformed teams together 
 
-#### Creating a positive learning environment
+**Solo learner groups**:
+* Learners could sign up alone but request to do the exercises in team
+* -> 2 open breakout rooms
+* Additional rooms for specific problem solving 
+* Learners can also form own team 
+
+**Make it easier for learners to ask for help**:
+* Rename yourself in Zoom to reflect your team name and that you are EL
+
+**Want extra help?**
+* It is ok to not know something!
+* We have structures in place to help you if
+  there is questions that you cannot answer (HackMD, expert helpers).
+
+**Use HackMD**:
+* to ask (and answer) general questions that came up in your room 
+* to call for more help from our expert helpers
+
+```{figure} img/breakout--exercises.png
+Example of HackMD during a breakout session.  a) clear description of
+topics of the exercises.  b) breakout room status.  c) as always,
+questions at the bottom.
+```
+
+
+## Your task during exercise sessions
+
+As an exercise leader in a breakout room, your main task is to **keep people talking
+and interacting, understand their difficulties, and encourage them to
+work on the exercises together**.
+
+- You can always start by **greeting** people and asking how the lesson is
+  going
+- Encourage people to **turn on cameras**
+- You can use chat within breakout rooms: Chat to "Everyone" in a
+  breakout room only means people in that room.
+- There are several strategies below.  Combine as needed - **read the
+  room and see what they want**, but do **provide encouragement** to do
+  something.
+- **If you need extra help, write it in the HackMD**, someone should be
+  watching it and relay it to the host. Expert helpers/instructors will try to
+  visit your rooms periodically, anyway.
+- **Watch the time** and try to keep things moving.  If some debugging
+  takes to long, it's reasonable to ask for an expert helper who might
+  have seen the problem before.
+    - If any one problem takes too long, it's OK to say "we don't have
+      time, let's come back"
+    - Or, ask for an expert helper to come by and maybe answer
+      quickly, or break off to work on a solution.
+
+```{figure} img/breakout--exercises.png
+Example of HackMD during a breakout session.  a) clear description of
+topics of the exercises.  b) breakout room status.  c) as always,
+questions at the bottom.
+```
+
+
+## Strategies for exercise rooms
+
+There are several strategies you can use to run your breakout room:
+
+Strategy 1:
+- **Exercise leader asks someone to share the screen and go through the exercise.**
+- You can encourage the others to guide the one who is sharing the
+  screen. Or let the person go on her/his own pace.
+  - If no one dares at first, you can also start sharing your screen and let the room tell you what to write.
+  - That way they see how it can go and the barrier shrinks.
+- Try to alternate who is sharing the screen for each session.
+- When someone has an issue, it is a good idea to switch screen share to them
+  and maybe even continue from there
+
+Strategy 2:
+- **Everyone does the exercises themselves, and once someone has a
+  question, encourage them to share the screen and you discuss.**
+- If everyone is active, this can be good, but there is a risk that no
+  one starts off.
+
+Strategy 3:
+- **You can also share the screen if no one is willing to.**
+- It might be good to give learners some lead first, and use this only
+  if no one volunteers.
+
+
+## Create a positive learning environment
 
 As an exercise leader, you have a crucial role during workshops:
 
@@ -306,8 +174,48 @@ As an exercise leader, you have a crucial role during workshops:
   wont.  Students rarely try to get your attention from across the room if you
   don't look ready.
 
-#### Things you should not do in a workshop
 
+## Common problems in exercise rooms
+
+- **One learner asks very many questions**, ends up monopolizing all of
+  the time.  Other learners are left without help, and the whole group
+  may not get the exercises done
+    - Call an expert helper to the room.  They should be circulating,
+      so let them know to spend some more time
+    - It can be very hard to say "no", but it's more important to have
+      balance than answer every question you are asked.  If you need
+      to say no, you can try things such as "I'm sorry, but in order
+      to finish we need to go on now.  We can keep working on it
+      later - would you like to watch?"
+- There is some sort of problem that ends up taking a **lot of time**
+    - Work on it for a minute or two.
+    - Ask for an expert helper to drop by, by writing in the HackMD.
+      Nothing wrong with this.
+
+
+## Code of Conduct
+
+Teaching isn't about helping those who are already "in", it is for
+those who aren't.  Thus, we follow [a code Codee of
+Conduct](https://coderefinery.org/about/code-of-conduct/) for all our
+interactions before, during and after workshops.
+
+If you see anything that is not supporting an equal learning environment,
+please mention it to one of instructors.
+
+
+## Things to avoid
+
+**Shorter version**:
+* Take over learners keyboard, you can share commands in chat
+* Criticize certain programs, operating systems, or GUI applications, or learners who use them (Excel, Windows, etc.).
+* Talk contemptuously or with scorn about any tool. 
+* Dive into complex or detailed technical discussions.
+* Pretend to know more than you do. Better to put a question on HackMD then. Trust.
+* Use "just", "easy", "simply", "basic", "trivial" or other demotivating words. 
+* "I can’t believe you don’t know X" 
+
+**Longer version**:
 - Take over the learner's keyboard (neither physically nor remotely). It is rarely a good idea to type anything
   for your learners and it can be demotivating for the learner because it
   implies you don't think they can do it themselves or that you don't want to
@@ -335,80 +243,106 @@ As an exercise leader, you have a crucial role during workshops:
   are teaching, that they don't belong at the workshop, and it may prevent them
   from asking questions in the future.
 
-### In the breakout room
 
-As an exercise leader in a breakout room, your main task is to *keep people talking
-and interacting, understand their difficulties, and encourage them to
-work on the exercises together.*
+## Path ahead
 
-- You can always start by greeting people and asking how the lesson is
-  going
-- Encourage people to turn on cameras
-- You can use chat within breakout rooms: Chat to "Everyone" in a
-  breakout room only means people in that room.
-- There are several strategies below.  Combine as needed - read the
-  room and see what they want, but do provide encouragement to do
-  something.
-- If you need extra help, write it in the HackMD, someone should be
-  watching it and relay it to the host. Expert helpers/instructors will try to
-  visit your rooms periodically, anyway.
-- Watch the time and try to keep things moving.  If some debugging
-  takes to long, it's reasonable to ask for an expert helper who might
-  have seen the problem before.
-    - If any one problem takes too long, it's OK to say "we don't have
-      time, let's come back"
-    - Or, ask for an expert helper to come by and maybe answer
-      quickly, or break off to work on a solution.
+Would you like to
+* become an instructor?
+* help organizing a workshop?
+* contribute to lesson material?
+* have any other ideas to contribute?
+* community calls: see https://coderefinery.org/organization/meetings/
 
-```{figure} img/breakout--exercises.png
-Example of HackMD during a breakout session.  a) clear description of
-topics of the exercises.  b) breakout room status.  c) as always,
-questions at the bottom.
-```
+See our [website](https://coderefinery.org/get-involved/) and {ref}`volunteering`.
+Best way to get started is to join the [Zulip chat](https://coderefinery.zulipchat.com).
 
-#### Breakout room strategies
 
-There are several strategies you can use to run your breakout room:
+## Background: hierarchical workshops to scale
 
-Strategy 1:
-- **Exercise leader asks someone to share the screen and go through the exercise.**
-- You can encourage the others to guide the one who is sharing the
-  screen. Or let the person go on her/his own pace.
-  - If no one dares at first, you can also start sharing your screen and let the room tell you what to write.
-  - That way they see how it can go and the barrier shrinks.
-- Try to alternate who is sharing the screen for each session.
-- When someone has an issue, it is a good idea to switch screen share to them
-  and maybe even continue from there
+Traditionally, a workshop has instructors and exercise leaders/helpers, but the
+capacity is limited by instructors, so we are limited to ~30-40 people
+at most.  Then, we tried to scale to larger numbers: even up to and beyond 100
+people.  For this, we have to rely on *exercise leaders* a lot more, to run a
+breakout room.  An exercise leader does not have to be an expert in the
+material, but should be able to keep things flowing.
 
-Strategy 2:
-- **Everyone does the exercises themselves, and once someone has a
-  question, encourage them to share the screen and you discuss.**
-- If everyone is active, this can be good, but there is a risk that no
-  one starts off.
+Exercise Leaders are an essential part of the CodeRefinery workshop team and
+allow CodeRefinery to scale to many more people than we could otherwise handle.
+During a (n online) workshop, Exercise leaders will be in a breakout room
+(virtual side room) with around 5 people, guide them through the course, keep
+time, and let us know when more help is needed during the exercise sessions.
+Instructors and expert helpers are always just one click away.  It is very
+likely that you'll grow as a mentor and learn how to be a more efficient
+teacher. 
 
-Strategy 3:
-- **You can also share the screen if no one is willing to.**
-- It might be good to give learners some lead first, and use this only
-  if no one volunteers.
 
-#### Common problems
+## What is needed to be an exercise leader?
 
-- One learner asks very many questions, ends up monopolizing all of
-  the time.  Other learners are left without help, and the whole group
-  may not get the exercises done
-    - Call an expert helper to the room.  They should be circulating,
-      so let them know to spend some more time
-    - It can be very hard to say "no", but it's more important to have
-      balance than answer every question you are asked.  If you need
-      to say no, you can try things such as "I'm sorry, but in order
-      to finish we need to go on now.  We can keep working on it
-      later - would you like to watch?"
-- There is some sort of problem that ends up taking a lot of time
-    - Work on it for a minute or two.
-    - Ask for an expert helper to drop by, by writing in the HackMD.
-      Nothing wrong with this.
+Most importantly, *you do not have to know everything* (we don't, either), but you are expected to:
 
-### See also
+- Have been to a CodeRefinery before and used git some since then, OR have some general experience with git (branching,
+  pull requests) and command line work, OR be able to generally follow
+  the path of the exercises that we have laid out.
+
+- Be present in your assigned breakout room during exercise sessions of the workshop.
+
+- Show a positive, motivating attitude to learners.
+
+- Keep exercises going and let us know when there are difficult questions!
+
+- Come to a one-hour "Exercise leader onboarding" (see below) before the workshop.
+
+> If you aren't sure if you can be an exercise leader: you probably can be one!
+
+
+## Background: Teams
+
+We try to arrange people in teams which stay together for all breakout
+sessions on all days.  This allows people to form a bond and get the
+rooms started sooner.  We will try to keep you in the same breakout
+room as long as we can, but we give no promises and will rearrange as
+needed when people can't attend.
+
+We sometimes allow people to register as teams: This could for example be a
+group colleagues/friends where one of the team members has a bit of knowledge
+on the tools presented in the workhop. This person can act as exercise leader
+for the workshop, but may still learn a thing or two themselves. In that way
+you can work with people you know and the barrier for asking questions and
+discuss together may be a bit lower than in a group of strangers. Since teams
+with exercise leaders are 'self-sustaining' we usually accept all team
+registrations, while registrations as single learner may be put on waiting list
+or, if applicable redirected to the stream, when they exceed our capacity based
+on the number of individual exercise leaders. 
+
+
+## Material for exercise leaders
+
+If you have been to a CodeRefinery workshop before, you will most likely know the following, but if unsure, also check these links: 
+
+- {ref}`HackMD mechanics <how-to-hackmd>`
+- {ref}`Zoom mechanics <how-to-zoom>` (if the workshop uses Zoom)
+- "How to attend" whatever kind of workshop we are doing (though we
+  will cover this the first day, too): {ref}`how to attend via livestream
+  <attend-stream>`, {ref}`how to attend via Zoom <attend-online>`, or 
+  {ref}`how to attend in-person <attend-inperson>`.
+
+If you have any doubts, questions, ideas or anything you want to tell
+us apart from these sessions, please let us know! We are here to help. 
+
+If you want to contact us before the workshop you can send an email to our general email address <support@coderefinery.org> or you can join the
+{doc}`CodeRefinery chat <chat>` (we recommend the `#workshops` stream,
+and if you can't find it then `#general` is good). During the
+workshop, we use a topic in `#workshop-chat` to coordinate (exercise
+leaders do *not* need to use this, use HackMD instead).
+
+During the workshop, HackMD (collaborative document) is our main communication channel, where you can ask questions or request us to visit your breakout room in case of tricky questions or further discussion potential.
+
+If you had fun being an exercise leader for the workshop, please visit our
+{ref}`contributing page <volunteering>` page, to find out about further
+volunteering possibilities within CodeRefinery.
+
+
+## See also
 
 * Carpentries instructor training
 * {ref}`Teaching Tech Together <teaching-tech-together>` chapters 8,


### PR DESCRIPTION
@samumantha here an attempt to make this one page that can be presented but also avoids repetition.

I hope I changed it towards the better. It is probably impossible to see this from the diff below and I recommend to merge and check the rendered page.

It is hopefully not too lengthy. I have tried to emphasize important points and some sections at the end can be skipped in an on-boarding session.