### PR TITLE
Adds info and guides regarding metadata and FAIR lesson materials

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -76,6 +76,9 @@ lesson-philosophy
 lesson-design
 lesson-review
 lesson-contribution
+lesson-fair
+lesson-metadata
+lesson-version
 ```
 
 Information on writing, reviewing, and maintaining our actual lesson materials.

--- a/content/lesson-credits.md
+++ b/content/lesson-credits.md
@@ -1,28 +1,12 @@
 # Lesson credits
 
-```{admonition} Page status
+To acknowledge all contributors to our material we have implemented `CITATION.cff` files to all our lesson repositories in 2025. See [lesson metadata](lesson-metadata.md) for the full reference on what's in these files and when they get updated.
 
-This is a draft/proposal as of 2024.
-```
+We've decided not to distinguish different levels of contribution: everyone who contributed more than a typo fix is listed as an author, if they wish so. 
 
-We hope to acknowledge all contributors to our material, but there are
-many different sizes of contributions to something as wide-ranging as
-CodeRefinery.  We have these levels of credit:
+In 2026 we also added bioschemas.yml, which in addition to author, also introduces a contributor field. We keep everyone as author in both files rather than splitting across the two.
 
-* **Editors** take an overall, long-term view, set the overall
-  strategy, and manage the fit of the various sections.  They merge
-  pull requests (but so can others).
-* **Contributors/Authors** have made contributions which are locally
-  significant to one part of the lesson, and take responsibility for
-  what they have added (along with the team).
-* **Acknowledgees** have made other contributions.
-
-Editors and contributors are listed in the `CITATION.cff` file within
-each repository and are includes as authors in the archived DOI in
-Zenodo.  Editors are usually mentioned in the README file itself.
-Acknowledgees are listed on the Github contributors pages (or
-READMEs if it's not via Github).
-
+In 2026 we also started with a more formal role of lesson maintainer. The current maintainer(s) are recorded in the `contact` field of `CITATION.cff`, and are also named in the README. See [lesson metadata](lesson-metadata.md#lesson-maintainer-metadata) for how this carries through to bioschemas.yml and Zenodo.
 
 ## Adding an author
 
@@ -34,27 +18,39 @@ consider:
   permanent
 - You will be included in future releases as well, unless you ask to be removed
 - Please send us: family-names, given-names, and if you want ORCID
-  ((reference of valid
-  keys)[https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson]).
+  ([reference of valid
+  keys](https://github.com/citation-file-format/citation-file-format/blob/main/schema-guide.md#definitionsperson)).
 
-Editors should be proactive reach out to people when they contribute,
+The preferred way is to open a pull request adding yourself directly to
+`CITATION.cff`, under the `authors:` list, for example:
+
+```yaml
+authors:
+  - family-names: Doe
+    given-names: Jane
+    orcid: "https://orcid.org/0000-0000-0000-0000"
+```
+
+New authors are usually appended at the end of the list; there is no
+strict ordering requirement. If you'd rather not deal with git/YAML,
+send us the same information and a [lesson maintainer](lesson-maintainer.md)
+will add it for you.
+
+Maintainers should be proactive reach out to people when they contribute,
 but everyone should also send a pull request to be included in
-CITATION.cff if you desire.  Note that nothing of the above is defined
-as only "git or in-writing contributions".
+CITATION.cff if you desire.  Note that not all contributions may be visible from the Git history. Often, multiple people are involved in change discussions. Those should at least be asked if they want to be named as author.
+
+Regenerating `bioschemas.yml` from `CITATION.cff` happens as part of
+[releasing a new version](lesson-version.md), so it doesn't need to be
+done manually when adding an author.
 
 
+## Adding an acknowledgee
 
-## Adding an acknowldegee
-
-There are very many, so we try to leave the Github contributions page
-as the main source of them.  They can also be added to the lesson
-README page if it's not a Github interaction (or if it's desired for
+There are very many, so we try to add them to the lesson
+README page if it's not based on a Github interaction (or if it's desired for
 some other reason).
 
 
 
-## Adding an editor
 
-Anyone is welcome to take a long-term view of the lesson to become a
-future editor.  Be active in Github/chat/our meetings/etc. and we will
-be happy to distribute the work and credit more.

--- a/content/lesson-credits.md
+++ b/content/lesson-credits.md
@@ -6,7 +6,7 @@ We've decided not to distinguish different levels of contribution: everyone who 
 
 In 2026 we also added bioschemas.yml, which in addition to author, also introduces a contributor field. We keep everyone as author in both files rather than splitting across the two.
 
-In 2026 we also started with a more formal role of lesson maintainer. The current maintainer(s) are recorded in the `contact` field of `CITATION.cff`, and are also named in the README. See [lesson metadata](lesson-metadata.md#lesson-maintainer-metadata) for how this carries through to bioschemas.yml and Zenodo.
+In 2026 we will also start with a more formal role of lesson maintainer. The current maintainer(s) will be recorded in the `contact` field of `CITATION.cff`, and are also named in the README. See [lesson metadata](lesson-metadata.md#lesson-maintainer-metadata) for how this carries through to bioschemas.yml and Zenodo.
 
 ## Adding an author
 

--- a/content/lesson-fair.md
+++ b/content/lesson-fair.md
@@ -18,7 +18,7 @@ All our lessons have been published on Zenodo in our CodeRefinery community. Eve
 
 ### 4. Register online
 
-We're still looking into which formal training registry would be a good fit (e.g. TeSS, OpenAIRE) — this is an open item. In the meantime, crawlers and catalogs can already discover and index our lessons through the `bioschemas.yml` metadata (see [lesson metadata](lesson-metadata.md)), and all our workshop lessons are linked from our website and the workshop event pages.
+Every lesson is already indexed in [OpenAIRE](https://support.zenodo.org/help/en-gb/18-general/169-what-is-openaire) automatically, since Zenodo harvests to OpenAIRE and every lesson release is published on Zenodo (see point 3). Crawlers and catalogs can also discover our lessons directly through the `bioschemas.yml` metadata (see [lesson metadata](lesson-metadata.md)), and all our workshop lessons are linked from our website and the workshop event pages. 
 
 ### 5. Define access rules
 

--- a/content/lesson-fair.md
+++ b/content/lesson-fair.md
@@ -1,0 +1,57 @@
+# Making CodeRefinery lessons FAIR
+
+## Ten simple rules for FAIR training material
+
+Following the [Ten simple rules for FAIR training material](https://doi.org/10.1371/journal.pcbi.1007854) we can determine how CodeRefinery lessons are FAIR (Findable, Accessible, Interoperable and Reusable):
+
+### 1. Share
+
+All our lesson materials live on GitHub in public repositories. All lessons use our Sphinx lesson template as basis and are written using markdown.
+
+### 2. Describe properly
+
+All our lesson repositories include a `CITATION.cff` and a `bioschemas.yml` with the lesson metadata. Some fields are still a work in progress. The CITATION.cff file automatically registers in GitHub and provides option for citation information. The bioschemas file is built into the lesson html website without being visible on the page, it can be read by special crawlers and catalogs. See [lesson metadata](lesson-metadata.md) for the full reference on these files.
+
+### 3. Give unique identity
+
+All our lessons have been published on Zenodo in our CodeRefinery community. Every new release in the GitHub lesson repository creates a new version on Zenodo under the same concept ID (ID linking to all versions of an entry). See [releasing a new version](lesson-version.md) for the release process.
+
+### 4. Register online
+
+We're still looking into which formal training registry would be a good fit (e.g. TeSS, OpenAIRE) — this is an open item. In the meantime, crawlers and catalogs can already discover and index our lessons through the `bioschemas.yml` metadata (see [lesson metadata](lesson-metadata.md)), and all our workshop lessons are linked from our website and the workshop event pages.
+
+### 5. Define access rules
+
+All our lesson materials live in public GitHub repositories. The CodeRefinery team and instructors have maintainer access to these repositories, everyone else can submit issues and pull requests.
+
+### 6. Use interoperable format
+
+All our lesson materials live on GitHub in public repositories. All lessons use our Sphinx lesson template as basis and are written using markdown and built automatically with Sphinx to GitHub pages using GitHub actions on push to main branch. Our documentation lesson teaches how to use Sphinx and how to deploy it using GitHub pages.
+
+### 7. Make reusable for trainers
+
+All our lesson materials are licensed under CC-BY. Everyone can copy, redistribute, remix, transform and build upon the material in any format, giving appropriate credit.
+
+All our lessons also include instructor notes with field reports from previous iterations of teaching, timing estimates and useful teaching related comments.
+
+### 8. Make usable for trainees
+
+Our workshop event page has information on audience, prerequisites and learning objectives. Some lessons have their own learning objectives and prerequisites, but no separate information on the audience.
+
+### 9. Welcome contributions
+
+We generally welcome contributions, especially from people teaching the lessons during our workshop. See our [lesson contribution guide](lesson-contribution.md) for how to contribute; currently this guide lives in our manuals repository rather than in each individual lesson repository.
+
+### 10. Keep materials up to date
+
+We generally update the lesson materials before every workshop together with instructors. We also have [lesson maintainers](lesson-maintainer.md) who keep an eye on each lesson between these updates.
+
+### Additional things we do for our workshop
+
+- Our workshop is streamed live on twitch, everyone can watch, no registration/account required.
+- The workshop recordings stay available on twitch for a week after streaming
+- We try to archive the recording on YouTube, without breaks, with subtitles and chapters for easier navigation.
+
+## Resources
+
+- Wiegers, L., & van Gelder, C. W. G. (2019). Illustration for "Ten simple rules for making training materials FAIR" (1.0). Zenodo. https://doi.org/10.5281/zenodo.3593258]

--- a/content/lesson-maintainer.md
+++ b/content/lesson-maintainer.md
@@ -48,10 +48,11 @@ but it's good if they can stay hands-on with the teaching some.
   Instead, it's OK to have sections with advanced material that aren't
   usually taught.
 * Manage cycles of major development.  Many ideas may pile up over
-  time, and at some point there are bigger changes.  The curator
+  time, and at some point there are bigger changes.  The maintainer
   should managing this process.  (Or maybe, when it's time for a big
-  change, a new curator comes in manages the
+  change, a new maintainer comes in manages the
   rearrangement/restructuring/rewrite, and takes over as the maintainer)
+* Create a new release when appropriate, see :doc:`lesson-version`
 * Talking with new instructors of the lesson and briefing them on the
   spirit of the lesson and common pitfalls.  (You aren't expected to
   always be the instructor, but if you can sometimes, great)

--- a/content/lesson-maintainer.md
+++ b/content/lesson-maintainer.md
@@ -1,5 +1,8 @@
 # Lesson maintainer
 
+This page is a suggestion. We will update in 2026 as we start implementing the maintainer 
+role for our lessons.
+
 Many people contribute to lesson and thus are "maintainers"  *The* lesson
 maintainer refers to the person managing all the contributions, like the
 editor of a [edited

--- a/content/lesson-metadata.md
+++ b/content/lesson-metadata.md
@@ -1,0 +1,269 @@
+# Lesson metadata
+
+To make our lessons citable, findable, and machine-readable (see
+[making lessons FAIR](lesson-fair.md)), each lesson repository carries
+two metadata files. This page is the reference for what they contain,
+where they live, and when they get updated — including a field-by-field
+guide for [setting up metadata on a new
+lesson](#setting-up-metadata-for-a-new-lesson). For the human side of
+"who gets listed", see [lesson credits](lesson-credits.md); for the
+step-by-step update process, see [releasing a new
+version](lesson-version.md).
+
+## Overview
+
+| File               | Location                | Added | Main fields                                                    | Read by                                            |
+|--------------------|--------------------------|-------|------------------------------------------------------------------|-----------------------------------------------------|
+| `CITATION.cff`     | root of each lesson repo | 2025  | authors, contact, title, abstract, version, date-released, doi (concept ID), license, url, repository-code, type, message, cff-version | GitHub "Cite this repository" button, Zenodo release |
+| `bioschemas.yml`   | root of each lesson repo | 2026  | name, author, version, license, identifier (from CITATION.cff); description, keywords, educationalLevel, inLanguage, teaches, url, isPartOf (Bioschemas-specific) | Bioschemas/schema.org crawlers and catalogs          |
+
+## `CITATION.cff`
+
+This is the [Citation File Format](https://citation-file-format.github.io/)
+standard. GitHub detects it automatically and shows a "Cite this
+repository" button on the repo page.
+
+Example, based on the [documentation lesson](https://github.com/coderefinery/documentation)'s `CITATION.cff`:
+
+```yaml
+cff-version: 1.2.0
+message: "If you use this lesson material, please cite it using these metadata."
+authors:
+- name: "CodeRefinery"
+- family-names: "Doe"
+  given-names: "Jane"
+- family-names: "Foe"
+  given-names: "John"
+title: "How to document your research software - CodeRefinery lesson"
+type: "dataset"
+abstract: "The lesson 'How to document your research software' gives an overview of the different ways how a code project can be documented: from small projects to larger projects. Markdown and Sphinx are central tools in this lesson."
+version: 2026-08-03
+doi: "10.5281/zenodo.8280234"
+date-released: 2026-08-03
+url: "https://coderefinery.github.io/documentation/"
+license: CC-BY-4.0
+repository-code: "https://github.com/coderefinery/documentation"
+```
+
+Fields we maintain, grouped by how often they change:
+
+Set once, rarely touched afterwards:
+- `cff-version` — version of the CFF schema itself, not our lesson.
+  Set by the lesson template.
+- `message` — boilerplate citation instruction, the same across lessons.
+- `type` — always `"dataset"`; CFF has no dedicated "training material" type.
+- `url` — link to the built lesson site.
+- `license` — e.g. `CC-BY-4.0`.
+- `repository-code` — link to the GitHub source repo.
+- `doi` — left as-is; it is the Zenodo *concept* DOI that links all
+  versions together, not the version-specific one.
+
+Updated whenever the lesson content or people change:
+- `title` and `abstract` — updated if the lesson's scope or focus
+  changes materially. Note that title should include " - CodeRefinery lesson" in the end of the title so that lessons can be connected to CodeRefinery from the citation.
+- `authors` — one entry per contributor. Individual people use
+  `family-names`/`given-names` (and optionally `orcid`); the project as
+  a whole is also listed as a single organizational author via `name:
+  "CodeRefinery"`. See [lesson credits](lesson-credits.md) for how a
+  person gets added. We don't distinguish smaller "contributor"-level
+  credit — anyone listed here is an author.
+- `contact` — the current [lesson maintainer(s)](lesson-maintainer.md),
+  same person format as `authors`. Updated whenever the maintainer
+  changes.
+
+Updated at release time:
+- `version` — set to the release date, not a semantic version, e.g.
+  `2026-08-03`. In practice this is kept identical to `date-released`.
+- `date-released` — the release date, format `YYYY-MM-DD`.
+
+Authors are updated on an ongoing basis, whenever someone contributes
+(via pull request, or a maintainer adding them). `version` and
+`date-released` only change as part of a release, see [releasing a new
+version](lesson-version.md).
+
+## `bioschemas.yml`
+
+This provides [Bioschemas](https://bioschemas.org/)/schema.org markup,
+using the `LearningResource` type. It's built into the lesson's HTML
+pages as embedded JSON-LD, without being visible on the page itself —
+it's meant to be read by crawlers and catalogs, not learners.
+
+Example, based on the [documentation
+lesson](https://github.com/coderefinery/documentation) (this is the
+JSON-LD actually embedded in the page; the source `bioschemas.yml` is
+equivalent):
+
+```json
+{
+    "@context": "https://schema.org/",
+    "@type": "LearningResource",
+    "@id": "https://coderefinery.github.io/documentation/",
+    "description": "The lesson 'How to document your research software' gives an overview of the different ways how a code project can be documented: from small projects to larger projects. Markdown and Sphinx are central tools in this lesson.",
+    "keywords": "Documentation, Sphinx",
+    "name": "How to document your research software",
+    "author": [
+        {
+            "@type": "Organization",
+            "name": "CodeRefinery"
+        },
+        {
+            "@type": "Person",
+            "name": "Jane Doe"
+        }
+    ],
+    "educationalLevel": "Beginner",
+    "identifier": "https://doi.org/10.5281/zenodo.8280234",
+    "inLanguage": "en-UK",
+    "license": "https://creativecommons.org/licenses/by/4.0/",
+    "teaches": "Understand the importance of writing code documentation together with the source code, Know what makes a good documentation, Learn what tools can be used for writing documentation, Be able to motivate a balanced decision: sometimes READMEs are absolutely enough",
+    "url": "https://coderefinery.github.io/documentation/",
+    "isPartOf": "https://coderefinery.org",
+    "version": "2023-08-03"
+}
+```
+
+Its metadata is regenerated from `CITATION.cff` by running
+`get_schema_info_from_cff.py` locally, so it should stay in sync
+automatically as part of a release rather than being edited by hand,
+but only for a subset of fields — the rest are Bioschemas-specific and
+maintained directly in `bioschemas.yml`.
+
+Auto-regenerated from `CITATION.cff` (see [releasing a new
+version](lesson-version.md)) — don't hand-edit these, they'll be
+overwritten at the next release:
+- `name` — from `title`
+- `author` — from `authors`; each `family-names`/`given-names` pair
+  becomes a single `name` string, and CodeRefinery keeps its
+  `Organization` type
+- `version` — from `version`
+- `license` — from `license`, converted from the SPDX identifier
+  (`CC-BY-4.0`) to its full URL
+- `identifier` — from `doi`, converted from the bare DOI to a full
+  `https://doi.org/...` URL
+
+Maintained directly in `bioschemas.yml` (no `CITATION.cff` equivalent
+— edit these by hand when they change):
+- `@context`, `@type` — fixed (`https://schema.org/`,
+  `LearningResource`)
+- `@id`, `url` — the canonical lesson URL
+- `description` — kept in sync with `abstract` in `CITATION.cff` by
+  hand
+- `keywords` — comma-separated topics
+- `educationalLevel` — e.g. `Beginner`
+- `inLanguage` — e.g. `en-UK`
+- `teaches` — comma-separated learning objectives
+- `isPartOf` — fixed, `https://coderefinery.org` for every lesson
+
+It also defines a separate `contributor` field distinct from
+`authors`. We've decided not to use that distinction: everyone stays
+under `authors` in both files, matching the `CITATION.cff` side.
+
+## Zenodo
+
+Every GitHub release triggers a new version in our [CodeRefinery
+Zenodo community](https://zenodo.org/communities/coderefinery), under
+the same concept DOI as previous releases (the concept DOI is the one
+kept as `doi` in `CITATION.cff`). The Zenodo record's metadata
+(title/authors/license/version) comes directly from `CITATION.cff` at
+release time — see the verification step in [releasing a new
+version](lesson-version.md).
+
+## Lesson maintainer metadata
+
+We started a more formal [lesson maintainer](lesson-maintainer.md) role
+in 2026. The current maintainer(s) are recorded in the `contact` field
+of `CITATION.cff` (same person format as `authors`), and are also named
+in the lesson's README.
+
+This still needs to be carried through to the other two places lesson
+metadata ends up:
+
+- **`bioschemas.yml`** — the closest semantic match is schema.org's
+  `maintainer` property. This isn't generated yet: the
+  `get_schema_info_from_cff.py` script currently only carries over
+  name/authors/version/license/identifier, so it needs a small update
+  per lesson repo to also map `contact` → `maintainer`.
+- **Zenodo** — our deposits go through a custom release workflow
+  (using the `ZENODO_TOKEN`/`ZENODO_CONCEPT_ID` secrets), not GitHub's
+  built-in Zenodo integration, so nothing is added automatically.
+  The natural mapping is a `contributors` entry with the Zenodo/DataCite
+  contributor type `ContactPerson`. That workflow lives in each lesson
+  repository rather than in this manuals repo, so it needs to be
+  updated there too, and it's worth checking what it currently sends
+  before assuming this mapping is live.
+
+## Setting up metadata for a new lesson
+
+New lessons start from the [Sphinx lesson
+template](https://github.com/coderefinery/sphinx-lesson-template),
+which already includes a skeleton `CITATION.cff` and `bioschemas.yml`.
+Go through both files field by field when setting up a new lesson.
+
+### `CITATION.cff`
+
+Leave as the template sets them:
+- `cff-version`, `message`, `type`
+- `license` — `CC-BY-4.0` for all our lessons
+
+Fill in now:
+- `title` — the lesson's title, ending in " - CodeRefinery lesson"
+- `abstract` — a short (1-3 sentence) description of what the lesson
+  covers
+- `authors` — start with the `CodeRefinery` organizational entry, plus
+  whoever is creating the lesson; more are added as people contribute,
+  see [lesson credits](lesson-credits.md)
+- `contact` — the initial [lesson maintainer](lesson-maintainer.md),
+  if one has already been assigned; otherwise add this once one is
+- `url` — the lesson's future GitHub Pages URL, i.e.
+  `https://coderefinery.github.io/<repo-name>/`
+- `repository-code` — the new GitHub repository's URL
+- `version`, `date-released` — today's date, format `YYYY-MM-DD`
+
+Leave blank until the first release:
+- `doi` — there's no concept DOI yet. Follow the prerequisites in
+  [releasing a new version](lesson-version.md) to set up the Zenodo
+  entry, then fill this in with the resulting concept DOI. Once set,
+  it never changes again.
+
+### `bioschemas.yml`
+
+Leave as the template sets them:
+- `@context`, `@type`
+
+Fill in now, matching the corresponding `CITATION.cff` fields (from
+the next release onward these stay in sync automatically, see above):
+- `name` — same as `title`, but without the " - CodeRefinery lesson"
+  suffix
+- `author` — the same people/organization as `authors`, one `name`
+  string per entry
+- `version` — same as `version` in `CITATION.cff`
+- `license` — full URL form of the license, e.g.
+  `https://creativecommons.org/licenses/by/4.0/`
+
+Fill in now, Bioschemas-specific (these are never auto-generated, so
+they need to be set once and kept up to date by hand as the lesson
+changes):
+- `@id`, `url` — same as `url` in `CITATION.cff`
+- `description` — same as `abstract`
+- `keywords` — comma-separated topics/tools covered
+- `educationalLevel` — e.g. `Beginner`, matching the lesson's stated
+  audience
+- `inLanguage` — `en-UK` for our English-language lessons
+- `teaches` — comma-separated learning objectives, matching the
+  lesson's own learning objectives if defined
+- `isPartOf` — always `https://coderefinery.org`
+
+Leave blank until the first release:
+- `identifier` — same reasoning as `doi` above; fill in once the
+  concept DOI exists.
+
+## When things get updated, at a glance
+
+- **As people contribute:** `CITATION.cff` authors list.
+- **When the maintainer changes:** `contact` in `CITATION.cff` (and,
+  once implemented, the corresponding `bioschemas.yml`/Zenodo fields).
+- **When the lesson's scope changes materially:** `title`, `abstract`.
+- **At release time:** `version`, `date-released` in `CITATION.cff`;
+  regenerate `bioschemas.yml`; new Zenodo version created.
+- **Rarely/manually:** `doi` (never, once set), `cff-version`,
+  `message`, `type`, `url`, `license`, `repository-code`.

--- a/content/lesson-version.md
+++ b/content/lesson-version.md
@@ -1,0 +1,31 @@
+# Releasing a new version of a lesson
+
+Many people may be updating the lessons at any time. Though at some point the new version should be released and stored on Zenodo. A good time would usually be after a workshop. This page describes the process to **release a new version**. See [lesson metadata](lesson-metadata.md) for a reference on what each metadata field means and where it lives.
+
+0. Prerequisites: 
+- The Zenodo entry is (co-)managed by Code Refinery Zenodo user.
+- The GitHub repository has a Zenodo environment set up with secret `ZENODO_TOKEN` and environment variable `ZENODO_CONCEPT_ID` (this is set to the ID shown in Zenodo for linking to ALL versions (with 10.0000/zenodo.1234567 -> 1234567 would be the concept ID)). 
+
+1. Update `CITATION.cff`
+
+- Bump `version` and `date-released` to the new release date (today, format YYYY-mm-dd).
+- Add/update authors if the contributor list changed. This should happen as part of updating the lesson, though may easily be forgotten, so double check: diff the commit authors since the last release tag against the `authors` list in `CITATION.cff`, e.g. `git log <last-version-tag>..HEAD --format='%an <%ae>' | sort -u`. Remember that not all contributions (discussions and reviews) may be on GitHub, so also check those separately. 
+- Leave `doi` as-is —  it is the concept ID for the whole lesson version set.
+
+2. Regenerate `bioschemas.yml`
+
+Run `python3 get_schema_info_from_cff.py` locally so the Bioschemas/schema.org metadata (name, authors, version, license, identifier) stays in sync with the `CITATION.cff` changes from step 1. You may also do manual updates to `bioschemas.yml` if there are any other developments. 
+
+3. Wait and check that GitHub pages are built
+
+After merging above changes, wait until GitHub pages were rebuilt (build action successful and `gh-pages` up to date). 
+
+4. Create a new release 
+
+Use the same version as in `CITATION.cff` as new tag (you can also create the tag beforehand) and name for the release. 
+
+5. Watch the workflow run and verify the output
+
+Confirm: new version created under the same concept DOI, both the zip and the versioned PDF attached, metadata (title/authors/license/version) matches the updated CITATION.cff. 
+
+Done!


### PR DESCRIPTION
Documents how CodeRefinery lessons are made FAIR, and introduces a single master metadata.yml file that CITATION.cff, bioschemas.yml, and the Zenodo deposit are all generated from automatically.

### New pages:

- lesson-fair.md: walks through the "Ten simple rules for FAIR training material" and how CodeRefinery lessons satisfy each one (sharing on GitHub, citation/discoverability metadata, Zenodo publishing, access rules, CC-BY licensing, etc.).
- lesson-metadata.md: the field-by-field reference for metadata.yml:  what each field means and where it ends up; how CITATION.cff and bioschemas.yml are generated from it automatically on push to main; how the Zenodo publish script reads metadata.yml directly at release time; and a step-by-step guide for setting up metadata on a brand-new lesson.
- lesson-version.md: describes the release process — bumping metadata.yml's version, letting CITATION.cff/bioschemas.yml regenerate themselves, waiting for the GitHub Pages build, doing the GitHub release, and verifying the resulting Zenodo version.

### Updated pages:

- lesson-credits.md: clarified that we don't split credit into author/contributor tiers (everyone past a typo-fix is an author); updated the "adding an author" flow to target metadata.yml instead of hand-editing CITATION.cff; documented the (not yet active) maintainers field; fixed a broken markdown link plus a heading typo.
- lesson-maintainer.md: marked as an initial suggestion, not an adopted role, as we don't currently have lesson maintainers, plus small wording fixes and a pointer to the new release-process page.
  
